### PR TITLE
i3-wm wiki url update

### DIFF
--- a/.config/i3/keybindings
+++ b/.config/i3/keybindings
@@ -7,7 +7,7 @@ All sources and updates are available at GitHub:
 https://github.com/endeavouros-team/i3-EndeavourOS
 
 For reference consult our WIKI:
-https://endeavouros.com/docs/window-tiling-managers/i3-wm/
+https://discovery.endeavouros.com/window-tiling-managers/i3-wm/2021/03/
 
  = windows key
 


### PR DESCRIPTION
i3-wm wiki url update

also instead of : https://discovery.endeavouros.com/window-tiling-managers/i3-wm/2021/03/
this url can be used : https://discovery.endeavouros.com/window-tiling-managers/i3-wm/
