### PR TITLE
Added rofi-shortcuts as an alternative help menu

### DIFF
--- a/.config/i3/config
+++ b/.config/i3/config
@@ -171,7 +171,24 @@ bindsym $mod+Return exec xfce4-terminal
 bindsym $mod+c kill
 
 # exit-menu
-bindsym $mod+Shift+e exec ~/.config/i3/scripts/shutdown_menu -p rofi -c
+#bindsym $mod+Shift+e exec ~/.config/i3/scripts/shutdown_menu -p rofi -c
+
+# Set shut down, restart and locking features 
+# Temporary workaround to shutdown_menu
+set $mode_system  (l)ock |  (e)xit |  s(u)spend |  (h)ibernate | ﰇ (r)eboot |  (S)hutdown
+mode "$mode_system" {
+    bindsym l exec --no-startup-id ~/.config/i3/scripts/blur-lock.sh, mode "default"
+    bindsym u exec --no-startup-id ~/.config/i3/scripts/blur-lock.sh && systemctl suspend, mode "default" 
+    bindsym e exec --no-startup-id i3-msg exit, mode "default"
+    bindsym h exec --no-startup-id ~/.config/i3/scripts/blur-lock.sh && systemctl hibernate, mode "default"
+    bindsym r exec --no-startup-id systemctl reboot, mode "default"
+    bindsym s exec --no-startup-id systemctl poweroff, mode "default"
+
+    # exit system mode: "Enter" or "Escape"
+    bindsym Return mode "default"
+    bindsym Escape mode "default"
+}
+#: }}}
 
 # Lock the system
 # lock with a picture:

--- a/.config/i3/config
+++ b/.config/i3/config
@@ -188,6 +188,10 @@ bindsym $mod+Shift+r restart
 # keybinding list in editor:
 bindsym $mod+F1 exec xed ~/.config/i3/keybindings
 
+# Uncomment to use rofi script instead
+# keybinding list rofi script
+#bindsym $mod+F1 exec xed ~/.config/i3/rofi-shortcuts
+
 # Backlight control
 bindsym XF86MonBrightnessUp exec xbacklight +10
 bindsym XF86MonBrightnessDown exec xbacklight -10

--- a/.config/i3/i3blocks.conf
+++ b/.config/i3/i3blocks.conf
@@ -136,6 +136,11 @@ interval=1
 full_text=
 command=~/.config/i3/scripts/keyhint.sh
 
+# Uncomment to use rofi script instead
+#[keybindings]
+#full_text=
+#command=~/.config/i3/scripts/rofi-shortcuts
+
 [time]
 #label= 
 command=date '+%a %d %b %H:%M:%S'

--- a/.config/i3/keybindings-rofi
+++ b/.config/i3/keybindings-rofi
@@ -1,0 +1,54 @@
+**~**Info**~EndeavourOS i3wm Keybindings cheat sheet
+i3~**info**~ = windows key
+i3~+Return~Start xfce4-terminal
+i3~+c~kill focused window
+i3~F9 or +i~Application menu search by typing (fancy Rofi menu):
+i3~F10 or +t~Window switcher menu (fancy Rofu menu):
+i3~+Shift+e~Fancy exit-menu on bottom right:
+i3~+l~Locks the screen with a picture or blurring the screen (options in config)
+i3~+Shift+c~Reload the configuration file
+i3~+Shift+r~Restart i3 inplace (preserves your layout/session, can be used to upgrade i3)
+i3~+F1~Full keybinding list in editor:
+i3~+j~Change windows focus left
+i3~+k~Change windows focus down
+i3~+b~Change windows focus up
+i3~+o~Change windows focus right
+i3~**Info**~alternatively you can use the cursor keys:
+i3~+Left~Focus left
+i3~+Down~Focus down
+i3~+Up~Focus up
+i3~+Right~Focus right
+i3~**Info**~Move a focused window
+i3~+Shift+j~Move left
+i3~+Shift+k~Move down
+i3~+Shift+b~Move up
+i3~+Shift+o~Move right
+i3~**Info**Alternatively you can use the cursor keys:
+i3~+Shift+Left~Move left
+i3~+Shift+Down~Move down
+i3~+Shift+Up~Move up
+i3~+Shift+Right~Move right
+i3~**Info**~Split orientation
+i3~+h~split h  	-split in horizontal orientantion
+i3~+v~split v		- split in vertical orientation
+i3~+f~Fullscreen toggle -enter fullscreen mode for the focused container
+i3~**Info**Layouts (stacked, tabbed, toggle split)
+i3~+s~Layout stacking
+i3~+g~Layout tabbed
+i3~+e~Layout toggle split
+i3~+Shift+space~Floating toggle (tiling / floating)
+i3~+space~Focus mode_toggle -change focus between tiling / floating windows
+i3~+a~Focus parent -focus the parent container
+i3~+d~Focus child -focus the child container
+i3~+right~Mouse button -resize floating window
+i3~+p~Multimedia Keys -Redirect sound to headphones
+i3~+w~Starts Firefox
+i3~+n~Starts Thunar
+i3~Print~Take a  screenshot
+info~##~to update this run the following command:
+info~##~wget backups=1 https://raw.githubusercontent.com/endeavouros-team/i3-EndeavourOS/master/.config/i3/keybindings -P ~/.config/i3/
+info~##~All sources and updates are available at GitHub:
+infi~##~https://github.com/endeavouros-team/i3-EndeavourOS
+info~##~For reference consult our WIKI:
+info~##~https://endeavouros.com/docs/window-tiling-managers/i3-wm/
+

--- a/.config/i3/scripts/rofi-shortcuts
+++ b/.config/i3/scripts/rofi-shortcuts
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+grep -v "|#|" -h ~/.config/i3/keybindings-rofi | 
+	column -t -s"~" -c 90 -N Name,Key,Action |
+	rofi\
+		-font "dejavu sans mono 10"\
+ 		-width 80\
+ 		-location 2\
+ 		-dmenu\
+ 		-i\
+ 		-p 'i3-Shortcuts'\
+ 		-hide-scrollbar
+


### PR DESCRIPTION
Basic modification just for testing rofi as an alternative to xed to get information about shortcuts configurations.
Can be expanded to include software specific shortcuts, system aliases, special command and many more since if fast and it integrates well with i3; Let me know how it goes.

Cheers.