### PR TITLE
Fix scrollbar syntax in rofi

### DIFF
--- a/.config/rofi/powermenu.rasi
+++ b/.config/rofi/powermenu.rasi
@@ -8,8 +8,6 @@ configuration {
     icon-theme: 		    "Arc-X-D";
     scroll-method:                  0;
     disable-history:                false;
-    fullscreen:                     false;
-    hide-scrollbar: 		    true;
     sidebar-mode: 		    false;
 }
 
@@ -29,6 +27,7 @@ window {
 listview {
     lines:                          6;
     columns:                        1;
+    scrollbar:                     false;
 }
 element {
     border:  0;

--- a/.config/rofi/rofidmenu.rasi
+++ b/.config/rofi/rofidmenu.rasi
@@ -10,8 +10,6 @@ configuration {
     drun-display-format:		"{name}";
     scroll-method:			0;
     disable-history:			false;
-    fullscreen:				false;
-    hide-scrollbar:			true;
     sidebar-mode:			false;
 }
 


### PR DESCRIPTION
Remove non function syntax and add correct syntax

 - **.config/rofi/powermenu.rasi**
  Remove `fullscreen` and `hide-scrollbar` attribute from `configuration` section. Add `scrollbar : false` to `listview` section.

- **.config/rofi/rofidmenu.rasi**
  Remove `fullscreen` and `hide-scrollbar` attribute from `configuration` section.

`fullscreen` and `hide-scrollbar` attribute in `configuration` section are not supported and Rofi throws warning if you use them.

