### PR TITLE
Corrected typo sesnors->sensors in i3blocks.conf

### DIFF
--- a/.config/i3/i3blocks.conf
+++ b/.config/i3/i3blocks.conf
@@ -96,7 +96,7 @@ interval=30
 #T_WARN=70
 #T_CRIT=90
 #SENSOR_CHIP=""
-# where SENSOR_CHIP can be find with sesnors output
+# where SENSOR_CHIP can be find with sensors output
 # can be used also for GPU temperature or other temperature sensors lm-sensors detects.
 
 # showing name of connected network (enable for wifi use)


### PR DESCRIPTION
Just found this typo and edited it. :) 