### PR TITLE
add example how to manage multiple keyboard layouts under i3

### DIFF
--- a/.config/i3/config
+++ b/.config/i3/config
@@ -338,6 +338,8 @@ exec --no-startup-id dex -a -s /etc/xdg/autostart/:~/.config/autostart/
 
 # num lock activated
 #exec --no-startup-id numlockx on
+# configure multiple keyboard layouts and hotkey to switch (Alt+CAPSLOCK in this example)
+#exec --no-startup-id setxkbmap -layout 'us,sk' -variant altgr-intl,qwerty -option 'grp:alt_caps_toggle'
 
 # start conky: 
 #exec_always --no-startup-id conky

--- a/.config/i3/i3blocks.conf
+++ b/.config/i3/i3blocks.conf
@@ -136,6 +136,11 @@ interval=1
 full_text=
 command=~/.config/i3/scripts/keyhint.sh
 
+# display keyboard layout name
+#[keyboard-layout]
+#command=~/.config/i3/scripts/keyboard-layout.sh
+#interval=2
+
 [time]
 #label= 
 command=date '+%a %d %b %H:%M:%S'

--- a/.config/i3/scripts/keyboard-switch.sh
+++ b/.config/i3/scripts/keyboard-switch.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+KBD=$(/usr/bin/xkblayout-state print '%s')
+echo $KBD
+


### PR DESCRIPTION
This is my way to manage multiple keyboards (english + slovak) under i3.
In this example (when uncommented) switching between layouts is possible by pressing `Alt`+`CAPS`.
The current layout name is displayed in i3blocks.