### PR TITLE
Fix blur lock reference in power menu

### DIFF
--- a/.config/i3/scripts/powermenu
+++ b/.config/i3/scripts/powermenu
@@ -118,7 +118,7 @@ menu=(
   [ Reboot]="systemctl reboot"
   [ Suspend]="systemctl suspend"
   [ Hibernate]="systemctl hibernate"
-  [ Lock]="~/.config/i3/scripts/blur-lock.sh"
+  [ Lock]="~/.config/i3/scripts/blur-lock"
   [ Logout]="i3-msg exit"
   [ Cancel]=""
 )


### PR DESCRIPTION
Pretty self explanatory from title.

I had this problem on my own recent install a few days ago, but I also looked in the repo code here to make sure the problem wasn't the result of a local change on my machine, and indeed the power menu script has a bad reference to the blur lock script.

P.S.: Really been enjoying Endeavour and i3 (first time for both), so thanks!