### PR TITLE
updated picom.conf

### DIFF
--- a/.config/picom.conf
+++ b/.config/picom.conf
@@ -1,13 +1,14 @@
 # Thank you code_nomad: http://9m.no/ꪯ鵞
 # and Arch Wiki contributors: https://wiki.archlinux.org/index.php/Compton
-
+# and picom Github: https://github.com/yshui/picom
 #################################
 #
 # Backend
 #
 #################################
 
-# Backend to use: "xrender" or "glx".
+# Specify the backend to use: `xrender`, `glx`, or `xr_glx_hybrid`.
+# `xrender` is the default one.
 # GLX backend is typically much faster but depends on a sane driver.
 backend = "glx";
 
@@ -17,24 +18,33 @@ backend = "glx";
 #
 #################################
 
+# GLX backend: Avoid using stencil buffer, useful if you don't have a stencil buffer.
+# Might cause incorrect opacity when rendering transparent content (but never
+# practically happened) and may not work with blur-background.
+# My tests show a 15% performance boost. Recommended.
 glx-no-stencil = true;
-
-# GLX backend: Copy unmodified regions from front buffer instead of redrawing them all.
-# My tests with nvidia-drivers show a 10% decrease in performance when the whole screen is modified,
-# but a 20% increase when only 1/4 is.
-# My tests on nouveau show terrible slowdown.
-glx-copy-from-front = false;
 
 # GLX backend: Use MESA_copy_sub_buffer to do partial screen update.
 # My tests on nouveau shows a 200% performance boost when only 1/4 of the screen is updated.
 # May break VSync and is not available on some drivers.
-# Overrides --glx-copy-from-front.
 # glx-use-copysubbuffermesa = true;
 
 # GLX backend: Avoid rebinding pixmap on window damage.
 # Probably could improve performance on rapid window content changes, but is known to break things on some drivers (LLVMpipe).
 # Recommended if it works.
 # glx-no-rebind-pixmap = true;
+
+# Disable the use of damage information.
+# This cause the whole screen to be redrawn everytime, instead of the part of the screen
+# has actually changed. Potentially degrades the performance, but might fix some artifacts.
+# The opposing option is use-damage
+# no-use-damage = false
+# use-damage = true;
+
+# Use X Sync fence to sync clients' draw calls, to make sure all draw
+# calls are finished before picom starts drawing. Needed on nvidia-drivers
+# with GLX backend for some users.
+xrender-sync-fence = true;
 
 # GLX backend: GLX buffer swap method we assume.
 # Could be undefined (0), copy (1), exchange (2), 3-6, or buffer-age (-1).
@@ -85,7 +95,6 @@ shadow-exclude = [
     "name *= 'picom'",
     "name *= 'Chromium'",
     "name *= 'Chrome'",
-    "class_g = 'Firefox' && argb",
     "class_g = 'Conky'",
     "class_g = 'Kupfer'",
     "class_g = 'Synapse'",
@@ -93,9 +102,12 @@ shadow-exclude = [
     "class_g ?= 'Cairo-dock'",
     "class_g ?= 'Xfce4-notifyd'",
     "class_g ?= 'Xfce4-power-manager'",
+    "(class_g = 'firefox' || class_g = 'Thunderbird') && (window_type = 'utility' || window_type = 'popup_menu') && argb",
     "_GTK_FRAME_EXTENTS@:c",
-    "_NET_WM_STATE@:32a *= '_NET_WM_STATE_HIDDEN'"
+    "_NET_WM_STATE@:32a *= '_NET_WM_STATE_HIDDEN'",
+    "_NET_WM_WINDOW_TYPE:a *= '_KDE_NET_WM_WINDOW_TYPE_OVERRIDE'"
 ];
+
 # Avoid drawing shadow on all shaped windows (see also: --detect-rounded-corners)
 shadow-ignore-shaped = false;
 
@@ -175,10 +187,6 @@ refresh-rate = 0;
 #vsync = true;
 vsync = false;
 
-# Enable DBE painting mode, intended to use with VSync to (hopefully) eliminate tearing.
-# Reported to have no effect, though.
-dbe = false;
-
 # Limit picom to repaint at most once every 1 / refresh_rate second to boost performance.
 # This should not be used with --vsync drm/opengl/opengl-oml as they essentially does --sw-opti's job already,
 # unless you wish to specify a lower refresh rate than the actual value.
@@ -217,13 +225,3 @@ wintypes:
         focus = true;
     };
 };
-
-######################
-#
-# XSync
-# See: https://github.com/yshui/picom/commit/b18d46bcbdc35a3b5620d817dd46fbc76485c20d
-#
-######################
-
-# Use X Sync fence to sync clients' draw calls. Needed on nvidia-drivers with GLX backend for some users.
-xrender-sync-fence = true;


### PR DESCRIPTION
Added new missing setting, and removed old deprecated settings.
Created shadow exclusions to fix glitches with certain context menus.

**References:**
https://man.archlinux.org/man/picom.1.en
https://github.com/yshui/picom/blob/next/picom.sample.conf
https://github.com/yshui/picom/issues/748
https://github.com/yshui/picom/issues/435

`glx-no-stencil`
Missing description.

`use-damage`
New setting.

`glx-copy-from-front`
`dbe`
Deprecated settings.

`xrender-sync-fence`
Moved up.