### PR TITLE
a few small corrections

### DIFF
--- a/.config/i3/scripts/keyhint
+++ b/.config/i3/scripts/keyhint
@@ -4,7 +4,7 @@ Main() {
     source /usr/share/endeavouros/scripts/eos-script-lib-yad || return 1
 
     local command=(
-        eos_yad --title="EndeavourOS i3-wm keybindings:" --no-buttons --geometry=405x345-15-400 --list
+        eos_yad --title="EndeavourOS i3-wm keybindings:" --no-buttons --geometry=400x345-15-400 --list
         --column=key: --column=description: --column=command:
         "ESC" "close this app" ""
         "=" "modkey" "(set mod Mod4)"

--- a/.config/i3/scripts/keyhint
+++ b/.config/i3/scripts/keyhint
@@ -4,7 +4,7 @@ Main() {
     source /usr/share/endeavouros/scripts/eos-script-lib-yad || return 1
 
     local command=(
-        eos_yad --title="EndeavourOS i3-wm keybindings:" --no-buttons --geometry=400x345-15-400 --list
+        eos_yad --title="EndeavourOS i3-wm keybindings:" --no-buttons --geometry=405x345-15-400 --list
         --column=key: --column=description: --column=command:
         "ESC" "close this app" ""
         "=" "modkey" "(set mod Mod4)"
@@ -16,7 +16,7 @@ Main() {
         "+q" "close focused app" ""
         "Print-key" "screenshot" ""
         "+Shift+e" "logout menu" ""
-        "+F1" "open keybinding helper" ""
+        "F1" "open keybinding helper" ""
     )
 
     "${command[@]}"

--- a/README.md
+++ b/README.md
@@ -14,9 +14,9 @@
 * [dex](https://github.com/jceb/dex) : autostarting apps from /etc/xdg/autostart/ (*)
 * Notifications are done with [dunst](https://dunst-project.org): CONFIG FILE = ~/.config/dunst/dunstrc
 
-**dex is commented in config, if you want autostarting like on a DE simply uncomment the line:** 
+**dex is enabled by default in config to autostart like on a DE. To disable, comment out the line:** 
 
-`exec --no-startup-id dex -a -s /etc/xdg/autostart/:~/.config/autostart/`
+`exec --no-startup-id dex --autostart --environment i3`
 
 inside `~/.config/i3/config`.
 
@@ -38,11 +38,11 @@ https://i3wm.org/docs/userguide.html#_default_keybindings
 
 ```
 # start a script to setup displays
-# uncomment the next line, use arandr to setup displays and save the file as monitor:
+# put `monitor.sh` into the location specified by this line:
 exec --no-startup-id ~/.screenlayout/monitor.sh
 ```
 this will handle to set display on each login.
-
+alternatively, you could manually make a script with xrandr.
 
 # Tiling:
 is set to default for i3wm and can be changed to: 

--- a/force-knowledge.md
+++ b/force-knowledge.md
@@ -2,9 +2,9 @@
 
 ## Dive into configure i3:
 
-To disable autostarting firefox with this readme edit `~/.config/i3/config` and comment out this line:
+To disable autostarting firefox with this readme, edit `~/.config/i3/config` and comment out this line:
 
-`#exec --no-startup-id firefox https://github.com/endeavouros-team/endeavouros-i3wm-setup/blob/main/README.md`
+`exec --no-startup-id sleep 7 && firefox https://github.com/endeavouros-team/endeavouros-i3wm-setup/blob/main/force-knowledge.md`
 
 `~/.config/i3/config` is the main configuration file for i3, get into this file and configure i3 as you like, all settings have comments to give you information about the following setting:
 
@@ -15,12 +15,11 @@ https://raw.githubusercontent.com/endeavouros-team/endeavouros-i3wm-setup/main/.
 enable picom in `~/.config/i3/config` by uncommenting this line:
 
 ```
-#transparency 
-exec --no-startup-id picom -CGb
+#exec --no-startup-id picom -b
 ```
 
-And in some cases you will need to use a different configuration ( Nvidia GPU/Driver p.e. but also others)
-Do some research will help you or ask at the chat or forum.
+And in some cases you will need to use a different configuration (Nvidia GPU/Driver p.e. but also others)
+Read the manpage, do some research will help you, or ask at the chat or forum.
 
 ## Not on a notebook? 
 ![alt text](https://raw.githubusercontent.com/endeavouros-team/screenshots/master/battery-red-i3.png "no-battery?")
@@ -39,8 +38,8 @@ Disable battery indicator in i3blocks.conf:
 
 ## autostart implementation:
 [dex](https://github.com/jceb/dex) is enabled in config per default:
-disable dex in `~/.config/i3/config` by uncommenting this line:
+disable dex in `~/.config/i3/config` by commenting out this line:
 
 ```
-#exec --no-startup-id dex --autostart --environment i3
+exec --no-startup-id dex --autostart --environment i3
 ```


### PR DESCRIPTION
`.config/i3/scripts/keyhint`
Fixed hotkey for keybinding helper which is set to F1 in config by default.
```
# keybinding in fancy rofi (automated):
bindsym F1 exec ~/.config/i3/scripts/keyhint-2
```

`README.md`
Updated instructions for **dex** and **arandr** since they are are now enabled by default.

`force-knowledge.md`
Updated exec path of **force-knowledge.md** and **picom**.
Revised instructions to optionally disable **dex**.