### PR TITLE
Clipboard manager for rofi

### DIFF
--- a/.config/i3/config
+++ b/.config/i3/config
@@ -550,3 +550,9 @@ bindsym $mod+t exec rofi -show window \
 
 #bindsym F10 exec rofi -show window \
 #		-config ~/.config/rofi/rofidmenu.rasi
+
+## rofi bindings to manage clipboard (install rofi-greenclip from the AUR)
+
+#exec --no-startup-id greenclip daemon>/dev/null
+#bindsym $mod+c exec --no-startup-id rofi -modi "clipboard:greenclip print" -show clipboard \
+#		-config ~/.config/rofi/rofidmenu.rasi


### PR DESCRIPTION
Add suggestion for clipboard manager for rofi using `rofi-greenclip` from the AUR.