### PR TITLE
Change fonts to Noto Sans and Noto Sans Mono and usual i3block fixes

### DIFF
--- a/.config/dunst/dunstrc
+++ b/.config/dunst/dunstrc
@@ -30,7 +30,7 @@
     height = 300
 
     # Position the notification in the top right corner
-    origin = bottom-right
+    origin = top-right
 
     # Offset from the origin
     offset = 30x30
@@ -111,7 +111,7 @@
 
     ### Text ###
 
-    font = Noto Sans Mono 9
+    font = Noto Sans 9
 
     # The spacing between lines.  If the height is smaller than the
     # font height, it will get raised to the font height.

--- a/.config/dunst/dunstrc
+++ b/.config/dunst/dunstrc
@@ -111,7 +111,7 @@
 
     ### Text ###
 
-    font = Noto Sans Mono 10
+    font = Noto Sans Mono 9
 
     # The spacing between lines.  If the height is smaller than the
     # font height, it will get raised to the font height.

--- a/.config/dunst/dunstrc
+++ b/.config/dunst/dunstrc
@@ -111,7 +111,7 @@
 
     ### Text ###
 
-    font = Noto Sans Regular 9
+    font = Noto Sans Mono 10
 
     # The spacing between lines.  If the height is smaller than the
     # font height, it will get raised to the font height.

--- a/.config/i3/config
+++ b/.config/i3/config
@@ -23,7 +23,7 @@ exec --no-startup-id ~/set_once.sh
 # is used in the bar {} block below.
 # This font is widely installed, provides lots of unicode glyphs, right-to-left
 # text rendering and scalability on retina/hidpi displays (thanks to pango).
-font pango:Noto Sans Mono 10
+font pango:Noto Sans 10
 
 # set the mod key to the winkey:
 set $mod Mod4
@@ -482,7 +482,7 @@ client.urgent		    $urgentred	$urgentred	$white		$purple		$yellowbrown
 # Start i3bar to display a workspace bar
 # (plus the system information i3status finds out, if available)
 bar {
-		font pango:Noto Sans Mono 10
+		font pango:Noto Sans 10
 		status_command i3blocks -c ~/.config/i3/i3blocks.conf
 	    	position bottom
 #	    	i3bar_command i3bar --transparency

--- a/.config/i3/config
+++ b/.config/i3/config
@@ -23,7 +23,7 @@ exec --no-startup-id ~/set_once.sh
 # is used in the bar {} block below.
 # This font is widely installed, provides lots of unicode glyphs, right-to-left
 # text rendering and scalability on retina/hidpi displays (thanks to pango).
-font pango:Noto Sans Regular 10
+font pango:Noto Sans Mono 10
 
 # set the mod key to the winkey:
 set $mod Mod4
@@ -162,6 +162,14 @@ bindcode $mod+Shift+90 	 move container to workspace  $ws10
 #}
 
 #bindsym $mod+r mode "resize"
+
+# Move the currently focused window to the scratchpad
+bindsym $mod+Shift+minus move scratchpad
+ 
+# Show the next scratchpad window or hide the focused scratchpad window.
+# If there are multiple scratchpad windows, this command cycles through them.
+bindsym $mod+minus scratchpad show
+# To remove a window from scratchpad toggle floating mode using $mod+Shift+space
 
 ######################################
 # keybindings for different actions: #
@@ -474,7 +482,7 @@ client.urgent		    $urgentred	$urgentred	$white		$purple		$yellowbrown
 # Start i3bar to display a workspace bar
 # (plus the system information i3status finds out, if available)
 bar {
-		font pango:Noto Sans Regular 10, FontAwesome 10
+		font pango:Noto Sans Mono 10
 		status_command i3blocks -c ~/.config/i3/i3blocks.conf
 	    	position bottom
 #	    	i3bar_command i3bar --transparency

--- a/.config/i3/config
+++ b/.config/i3/config
@@ -61,7 +61,7 @@ gaps outer 3
 #default_border normal
 
 # window title alignment
-#title_align center
+title_align center
 
 # Use Mouse+$mod to drag floating windows to their wanted position
 floating_modifier $mod
@@ -470,9 +470,9 @@ set $yellowbrown	#e1b700
 
 # define colors for windows:
 #class		        	border		bground		text		indicator	child_border
-client.focused		    $lightblue	$darkblue	$white		$purple		$mediumgrey
-client.unfocused	    $darkblue	$darkblue	$grey		$purple		$darkgrey
-client.focused_inactive	$darkblue	$darkblue	$grey		$purple		$black
+client.focused		    $lightblue	$darkgrey	$white		$purple		$mediumgrey
+client.unfocused	    $darkblue	$darkgrey	$grey		$purple		$lightblue
+client.focused_inactive	$darkblue	$darkgrey	$grey		$purple		$black
 client.urgent		    $urgentred	$urgentred	$white		$purple		$yellowbrown
 
 ############################################
@@ -501,11 +501,11 @@ strip_workspace_numbers yes
 		    separator          $purple
 		    background         $darkgrey
 		    statusline         $white
-#                          		border 		        bg		txt		indicator
+#  		border 		        bg				txt			indicator
 		focused_workspace	$mediumgrey	   	$grey		$darkgrey	$purple
-		active_workspace	$lightblue      	$mediumgrey	$darkgrey	$purple
-		inactive_workspace	$darkgrey   		$darkgrey	$grey		$purple
-		urgent_workspace	$urgentred	    	$urgentred	$white		$purple
+		active_workspace	$lightblue      $mediumgrey	$darkgrey	$purple
+		inactive_workspace	$darkgrey   	$darkgrey	$grey		$purple
+		urgent_workspace	$urgentred	    $urgentred	$white		$purple
 	}
 }
 

--- a/.config/i3/i3blocks.conf
+++ b/.config/i3/i3blocks.conf
@@ -37,21 +37,22 @@
 # Global properties
 #
 # The top properties below are applied to every block, but can be overridden.
-separator=false
 markup=pango
+separator=false
+align=center
 
 [terminal]
-full_text= 
+full_text=
 color=#807dfe
 command=i3-msg -q exec xfce4-terminal
 
 [browser]
-full_text= 
+full_text=
 color=#ff7f81
 command=i3-msg -q exec firefox
 
 [files]
-full_text= 
+full_text=
 color=#7f3fbf
 command=i3-msg -q exec thunar ~/
 
@@ -60,8 +61,8 @@ command=i3-msg -q exec thunar ~/
 #color=#dbcb75
 #command=i3-msg -q exec thunderbird
 
-[simple-2]
-full_text=: :
+[separator]
+full_text=〉
 color=#717171
 
 # Disk usage
@@ -99,6 +100,15 @@ interval=30
 # where SENSOR_CHIP can be find with sensors output
 # can be used also for GPU temperature or other temperature sensors lm-sensors detects.
 
+[separator]
+full_text=〉
+color=#717171
+
+#[arch-update]
+#label=Updates: 
+#command=~/.config/i3/scripts/arch-update 
+#interval=3600
+
 # showing name of connected network (enable for wifi use)
 #[net]
 #label=
@@ -117,10 +127,6 @@ command=~/.config/i3/scripts/battery2
 label=
 interval=30
 
-[simple-2]
-full_text=: :
-color=#717171
-
 [pavucontrol]
 full_text=
 command=pavucontrol
@@ -137,10 +143,6 @@ interval=1
 #command=~/.config/i3/scripts/keyboard-layout
 #interval=2
 
-[keybindings]
-full_text=
-command=~/.config/i3/scripts/keyhint
-
 #set power-profile
 [ppd_menu]
 full_text=
@@ -152,15 +154,46 @@ color=#407437
 command=~/.config/i3/scripts/ppd-status
 interval=5
 
+#[backlight]
+#command=~/.config/i3/scripts/backlight
+#label=☀
+#interval=20
+#STEP_SIZE=5
+#USE_SUDO=0
+
+[separator]
+full_text=〉
+color=#717171
+
 [time]
-#label=
+label=
 command=date '+%a %d %b %H:%M:%S'
 interval=1
+
+[separator]
+full_text=〉
+color=#717171
+
+[restart i3]
+full_text=
+command=i3-msg -q restart
+ 
+[keybindings]
+full_text=
+command=~/.config/i3/scripts/keyhint
+ 
+[EndevourOS Forum]
+full_text=
+command=i3-msg -q exec xdg-open https://forum.endeavouros.com/
+ 
+[EndevourOS Wiki]
+full_text=
+command=i3-msg -q exec xdg-open https://discovery.endeavouros.com/wiki/
 
 [shutdown_menu]
 full_text=
 command=~/.config/i3/scripts/powermenu
 
-[simple-2]
-full_text=: :
+[separator]
+full_text=〉
 color=#717171

--- a/.config/i3/i3blocks.conf
+++ b/.config/i3/i3blocks.conf
@@ -182,13 +182,13 @@ command=i3-msg -q restart
 full_text=
 command=~/.config/i3/scripts/keyhint
 
-[EndevourOS Forum]
-full_text=
-command=i3-msg -q exec xdg-open https://forum.endeavouros.com/
+#[EndevourOS Forum]
+#full_text=
+#command=i3-msg -q exec xdg-open https://forum.endeavouros.com/
 
-[EndevourOS Wiki]
-full_text=
-command=i3-msg -q exec xdg-open https://discovery.endeavouros.com/wiki/
+#[EndevourOS Wiki]
+#full_text=
+#command=i3-msg -q exec xdg-open https://discovery.endeavouros.com/wiki/
 
 [shutdown_menu]
 full_text=

--- a/.config/i3/i3blocks.conf
+++ b/.config/i3/i3blocks.conf
@@ -168,7 +168,7 @@ color=#717171
 [time]
 label=
 command=date '+%a %d %b %H:%M:%S'
-interval=1
+interval=5
 
 [separator]
 full_text=〉
@@ -177,15 +177,15 @@ color=#717171
 [restart i3]
 full_text=
 command=i3-msg -q restart
- 
+
 [keybindings]
 full_text=
 command=~/.config/i3/scripts/keyhint
- 
+
 [EndevourOS Forum]
 full_text=
 command=i3-msg -q exec xdg-open https://forum.endeavouros.com/
- 
+
 [EndevourOS Wiki]
 full_text=
 command=i3-msg -q exec xdg-open https://discovery.endeavouros.com/wiki/

--- a/.config/i3/scripts/arch-update
+++ b/.config/i3/scripts/arch-update
@@ -1,0 +1,134 @@
+#!/usr/bin/env python3
+#
+# Copyright (C) 2017 Marcel Patzwahl
+# Licensed under the terms of the GNU GPL v3 only.
+#
+# i3blocks blocklet script to see the available updates of pacman and the AUR
+import subprocess
+from subprocess import check_output
+import argparse
+import os
+import re
+
+
+def create_argparse():
+    def _default(name, default="", arg_type=str):
+        val = default
+        if name in os.environ:
+            val = os.environ[name]
+        return arg_type(val)
+
+    strbool = lambda s: s.lower() in ["t", "true", "1"]
+    strlist = lambda s: s.split()
+
+    parser = argparse.ArgumentParser(description="Check for pacman updates")
+    parser.add_argument(
+        "-b",
+        "--base_color",
+        default=_default("BASE_COLOR", "green"),
+        help="base color of the output(default=green)",
+    )
+    parser.add_argument(
+        "-u",
+        "--updates_available_color",
+        default=_default("UPDATE_COLOR", "yellow"),
+        help="color of the output, when updates are available(default=yellow)",
+    )
+    parser.add_argument(
+        "-a",
+        "--aur",
+        action="store_const",
+        const=True,
+        default=_default("AUR", "False", strbool),
+        help="Include AUR packages. Attn: Yaourt must be installed",
+    )
+    parser.add_argument(
+        "-q",
+        "--quiet",
+        action="store_const",
+        const=True,
+        default=_default("QUIET", "False", strbool),
+        help="Do not produce output when system is up to date",
+    )
+    parser.add_argument(
+        "-w",
+        "--watch",
+        nargs="*",
+        default=_default("WATCH", arg_type=strlist),
+        help="Explicitly watch for specified packages. "
+        "Listed elements are treated as regular expressions for matching.",
+    )
+    return parser.parse_args()
+
+
+def get_updates():
+    output = ""
+    try:
+        output = check_output(["checkupdates"]).decode("utf-8")
+    except subprocess.CalledProcessError as exc:
+        # checkupdates exits with 2 and no output if no updates are available.
+        # we ignore this case and go on
+        if not (exc.returncode == 2 and not exc.output):
+            raise exc
+    if not output:
+        return []
+
+    updates = [line.split(" ")[0] for line in output.split("\n") if line]
+
+    return updates
+
+
+def get_aur_updates():
+    output = ""
+    try:
+        output = check_output(["yaourt", "-Qua"]).decode("utf-8")
+    except subprocess.CalledProcessError as exc:
+        # yaourt exits with 1 and no output if no updates are available.
+        # we ignore this case and go on
+        if not (exc.returncode == 1 and not exc.output):
+            raise exc
+    if not output:
+        return []
+
+    aur_updates = [
+        line.split(" ")[0] for line in output.split("\n") if line.startswith("aur/")
+    ]
+
+    return aur_updates
+
+
+def matching_updates(updates, watch_list):
+    matches = set()
+    for u in updates:
+        for w in watch_list:
+            if re.match(w, u):
+                matches.add(u)
+
+    return matches
+
+
+label = os.environ.get("LABEL", "")
+message = "{0}<span color='{1}'>{2}</span>"
+args = create_argparse()
+
+updates = get_updates()
+if args.aur:
+    updates += get_aur_updates()
+
+update_count = len(updates)
+if update_count > 0:
+    if update_count == 1:
+        info = str(update_count) + " update available"
+        short_info = str(update_count) + " update"
+    else:
+        info = str(update_count) + " updates available"
+        short_info = str(update_count) + " updates"
+
+    matches = matching_updates(updates, args.watch)
+    if matches:
+        info += " [{0}]".format(", ".join(matches))
+        short_info += "*"
+    print(message.format(label, args.updates_available_color, info))
+    print(message.format(label, args.updates_available_color, short_info))
+elif not args.quiet:
+    print(message.format(label, args.base_color, "system up to date"))

--- a/.config/i3/scripts/backlight
+++ b/.config/i3/scripts/backlight
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+
+# Show the screen brightness value given by `xbacklight`.
+# Clicking uses `xset` to turn off the backlight, scrolling increases or decreases
+# the brightness.
+
+# Copyright 2019 Johannes Lange
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+
+STEP_SIZE=${STEP_SIZE:-5}
+USE_SUDO=${USE_SUDO:-0}
+
+# whether to use `sudo` for changing the brightness (requires a NOPASSWD rule)
+if [[ "$USE_SUDO" == "0" ]] ; then
+    XBACKLIGHT_SET="xbacklight"
+else
+    XBACKLIGHT_SET="sudo xbacklight"
+fi
+
+case $BLOCK_BUTTON in
+  3) xset dpms force off ;; # right click
+  4) $XBACKLIGHT_SET -inc "$STEP_SIZE" ;; # scroll up
+  5) $XBACKLIGHT_SET -dec "$STEP_SIZE" ;; # scroll down, decrease
+esac
+
+
+BRIGHTNESS=$(xbacklight -get | cut -f1 -d'.')
+echo "${BRIGHTNESS}%"

--- a/.config/rofi/power-profiles.rasi
+++ b/.config/rofi/power-profiles.rasi
@@ -4,7 +4,7 @@
  *******************************************************/
 
 configuration {
-    font:                           "Sourcecode Pro Regular 10";
+    font:                           "Noto Sans Mono 10";
     show-icons:                     false;
 	icon-theme: 					"Arc-X-D";
     scroll-method:                  0;

--- a/.config/rofi/power-profiles.rasi
+++ b/.config/rofi/power-profiles.rasi
@@ -4,7 +4,7 @@
  *******************************************************/
 
 configuration {
-    font:                           "Noto Sans Mono 10";
+    font:                           "Noto Sans 10";
     show-icons:                     false;
 	icon-theme: 					"Arc-X-D";
     scroll-method:                  0;
@@ -19,7 +19,7 @@ configuration {
 
 window {
     background-color:               @background;
-    border:                         0;
+    border:                         1;
     padding:                        10;
     transparency:                   "real";
     width:                          170px;

--- a/.config/rofi/powermenu.rasi
+++ b/.config/rofi/powermenu.rasi
@@ -3,7 +3,7 @@
  * Maintainer: joekamprad <joekamprad@endeavouros.com>
  *******************************************************/
 configuration {
-    font:                           "Sourcecode Pro Regular 10";
+    font:                           "Noto Sans Mono 10";
     show-icons:                     false;
     icon-theme: 		    "Arc-X-D";
     scroll-method:                  0;

--- a/.config/rofi/powermenu.rasi
+++ b/.config/rofi/powermenu.rasi
@@ -3,7 +3,7 @@
  * Maintainer: joekamprad <joekamprad@endeavouros.com>
  *******************************************************/
 configuration {
-    font:                           "Noto Sans Mono 10";
+    font:                           "Noto Sans 10";
     show-icons:                     false;
     icon-theme: 		    "Arc-X-D";
     scroll-method:                  0;
@@ -15,7 +15,7 @@ configuration {
 
 window {
     background-color:               @background;
-    border:                         0;
+    border:                         1;
     padding:                        10;
     transparency:                   "real";
     width:                          120px;

--- a/.config/rofi/rofidmenu.rasi
+++ b/.config/rofi/rofidmenu.rasi
@@ -3,7 +3,7 @@
  * Maintainer: joekamprad <joekamprad@endeavouros.com>
  *******************************************************/
 configuration {
-    font:				"Noto Sans Mono 10";
+    font:				"Noto Sans 10";
     show-icons:				true;
     icon-theme:				"Arc-X-D";
     display-drun:			"Apps";
@@ -17,7 +17,7 @@ configuration {
 
 window {
     background-color: @background;
-    border:           0;
+    border:           1;
     padding:          30;
 }
 listview {

--- a/.config/rofi/rofidmenu.rasi
+++ b/.config/rofi/rofidmenu.rasi
@@ -3,7 +3,7 @@
  * Maintainer: joekamprad <joekamprad@endeavouros.com>
  *******************************************************/
 configuration {
-    font:				"Sourcecode Pro Regular 10";
+    font:				"Noto Sans Mono 10";
     show-icons:				true;
     icon-theme:				"Arc-X-D";
     display-drun:			"Apps";

--- a/.config/rofi/rofikeyhint.rasi
+++ b/.config/rofi/rofikeyhint.rasi
@@ -3,7 +3,7 @@
  * Maintainer: joekamprad <joekamprad@endeavouros.com>
  *******************************************************/
 configuration {
-    font:                           "Noto Sans Mono 10";
+    font:                           "Noto Sans 10";
     show-icons:                     false;
 	icon-theme: 					"Arc-X-D";
     display-drun: 					"KeyHint";
@@ -19,7 +19,7 @@ configuration {
 
 window {
     background-color: @background;
-    border:           0;
+    border:           1;
     padding:          30;
 }
 listview {

--- a/.config/rofi/rofikeyhint.rasi
+++ b/.config/rofi/rofikeyhint.rasi
@@ -3,7 +3,7 @@
  * Maintainer: joekamprad <joekamprad@endeavouros.com>
  *******************************************************/
 configuration {
-    font:                           "Sourcecode Pro Regular 10";
+    font:                           "Noto Sans Mono 10";
     show-icons:                     false;
 	icon-theme: 					"Arc-X-D";
     display-drun: 					"KeyHint";

--- a/.config/xfce4/terminal/terminalrc
+++ b/.config/xfce4/terminal/terminalrc
@@ -37,6 +37,6 @@ TabActivityColor=#81813d3d9c9c
 ColorCursorUseDefault=FALSE
 ColorBoldIsBright=FALSE
 ScrollingUnlimited=TRUE
-FontName=Source Code Pro 10
+FontName=Noto Sans Mono 10
 ColorPalette=rgb(0,0,0);rgb(170,0,0);rgb(76,61,170);rgb(170,85,0);rgb(0,0,170);rgb(170,0,170);rgb(0,170,170);rgb(170,170,170);rgb(85,85,85);rgb(255,85,85);rgb(85,255,85);rgb(255,255,85);rgb(85,85,255);rgb(255,85,255);rgb(85,255,255);rgb(255,255,255)
 ScrollingBar=TERMINAL_SCROLLBAR_NONE

--- a/force-knowledge.md
+++ b/force-knowledge.md
@@ -28,12 +28,12 @@ To disable battery indicator edit the file `~/.config/i3/i3blocks.conf` and comm
 
 ```
 # Battery indicator
-#[battery]
-#command=~/.config/i3/scripts/battery2
+[battery]
+command=~/.config/i3/scripts/battery2
 # for alternative battery script  change to battery1
 # change this to battery-pinebook-pro if you are running on pinebook-pro
-#label=
-#interval=30
+label=
+interval=30
 ```
 
 ## Autostart implementation


### PR DESCRIPTION
`.config/i3/config`

- Add scratchpad binding and remove FontAwesome font from i3block config.

`.config/i3/i3blocks.conf`

- Add block to show pacman updates, brightness, EndevourOS Forum, EndevourOS Wiki and restart i3.

Change `Source Code Pro` to `Noto Sans` in these places:

- `.config/dunst/dunstrc`
- `.config/i3/config`
- `.config/rofi/power-profiles.rasi`
- `.config/rofi/powermenu.rasi`
- `.config/rofidmenu.rasi`
- `.config/rofi/rofikeyhint.rasi`