### PR TITLE
Update blur-lock

### DIFF
--- a/.config/i3/scripts/blur-lock
+++ b/.config/i3/scripts/blur-lock
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 PICTURE=/tmp/i3lock.png
-SCREENSHOT="scrot $PICTURE"
+SCREENSHOT="scrot -z $PICTURE"
 
 BLUR="5x4"
 


### PR DESCRIPTION
Adding the `-z` option before scrots prevents the beep sound after executing the script on locking the system with <kbd>Mod+L</kbd>.

Fixes:
*https://github.com/endeavouros-team/endeavouros-i3wm-setup/issues/42
*https://forum.endeavouros.com/t/removing-i3-lock-sound/26226.