### PR TITLE
Rofi: remove redundant settings

### DIFF
--- a/.config/rofi/power-profiles.rasi
+++ b/.config/rofi/power-profiles.rasi
@@ -26,7 +26,6 @@ window {
     location:                       east;
     /*y-offset:                       18;*/
     /*x-offset:	                    850;*/
-    transparency:                   "real";
 }
 listview {
     lines:                           4;

--- a/.config/rofi/powermenu.rasi
+++ b/.config/rofi/powermenu.rasi
@@ -22,7 +22,6 @@ window {
     location:                       east;
 /*y-offset:                       18;*/
 /*x-offset:	                    850;*/
-    transparency:                   "real";
 }
 listview {
     lines:                          6;


### PR DESCRIPTION
I saw in the `powermenu.rasi` file a setting that was set twice in the `window` block. I decided to check (quickly) all the rofi files and deleted 1 attribute in :
- `powermenu.rasi`
- `power-profiles.rasi`