### PR TITLE
style: Correct formatting inconsistencies in rofi config

### DIFF
--- a/.config/rofi/power-profiles.rasi
+++ b/.config/rofi/power-profiles.rasi
@@ -2,38 +2,37 @@
  * ROFI configs i3 powermenu for EndeavourOS
  * Maintainer: joekamprad <joekamprad@endeavouros.com>
  *******************************************************/
-
 configuration {
-    font:                           "Noto Sans Regular 10";
-    show-icons:                     false;
-    icon-theme: 					"Qogir";
-    scroll-method:                  0;
-    disable-history:                false;
-    fullscreen:                     false;
-	hide-scrollbar: 				true;
-	sidebar-mode: 					false;
+    font:             "Noto Sans Regular 10";
+    show-icons:       false;
+    icon-theme:       "Qogir";
+    scroll-method:    0;
+    disable-history:  false;
+    fullscreen:       false;
+    hide-scrollbar:   true;
+    sidebar-mode:     false;
 }
 
 @import "~/.config/rofi/arc_dark_colors.rasi"
 
 
 window {
-    background-color:               @background;
-    border:                         0;
-    padding:                        10;
-    transparency:                   "real";
-    width:                          170px;
-    location:                       east;
-    /*y-offset:                       18;*/
-    /*x-offset:	                    850;*/
+    background-color: @background;
+    border:           0;
+    padding:          10;
+    transparency:     "real";
+    width:            170px;
+    location:         east;
+    /*y-offset:       18;*/
+    /*x-offset:       850;*/
 }
 listview {
-    lines:                           4;
-    columns:                        1;
+    lines:   4;
+    columns: 1;
 }
 element {
     border:  0;
-    padding: 1px ;
+    padding: 1px;
 }
 element-text {
     background-color: inherit;
@@ -76,14 +75,14 @@ element.alternate.active {
     text-color:       @alternate-active-foreground;
 }
 scrollbar {
-    width:        4px ;
+    width:        4px;
     border:       0;
     handle-color: @normal-foreground;
-    handle-width: 8px ;
+    handle-width: 8px;
     padding:      0;
 }
 mode-switcher {
-    border:       2px 0px 0px ;
+    border:       2px 0px 0px;
     border-color: @separatorcolor;
 }
 button {
@@ -97,7 +96,7 @@ button.selected {
 inputbar {
     spacing:    0;
     text-color: @normal-foreground;
-    padding:    1px ;
+    padding:    1px;
 }
 case-indicator {
     spacing:    0;
@@ -117,6 +116,6 @@ inputbar {
 textbox-prompt-colon {
     expand:     false;
     str:        "Set Power Profile:";
-    margin:     0px 0.3em 0em 0em ;
+    margin:     0px 0.3em 0em 0em;
     text-color: @normal-foreground;
 }

--- a/.config/rofi/powermenu.rasi
+++ b/.config/rofi/powermenu.rasi
@@ -3,34 +3,34 @@
  * Maintainer: joekamprad <joekamprad@endeavouros.com>
  *******************************************************/
 configuration {
-    font:                           "Noto Sans Regular 10";
-    show-icons:                     false;
-    icon-theme: 		    "Qogir";
-    scroll-method:                  0;
-    disable-history:                false;
-    sidebar-mode: 		    false;
+    font:            "Noto Sans Regular 10";
+    show-icons:      false;
+    icon-theme:      "Qogir";
+    scroll-method:   0;
+    disable-history: false;
+    sidebar-mode:    false;
 }
 
 @import "~/.config/rofi/arc_dark_transparent_colors.rasi"
 
 window {
-    background-color:               @background;
-    border:                         0;
-    padding:                        10;
-    transparency:                   "real";
-    width:                          120px;
-    location:                       east;
-/*y-offset:                       18;*/
-/*x-offset:	                    850;*/
+    background-color: @background;
+    border:           0;
+    padding:          10;
+    transparency:     "real";
+    width:            120px;
+    location:         east;
+    /*y-offset:       18;*/
+    /*x-offset:       850;*/
 }
 listview {
-    lines:                          6;
-    columns:                        1;
-    scrollbar:                     false;
+    lines:     6;
+    columns:   1;
+    scrollbar: false;
 }
 element {
     border:  0;
-    padding: 1px ;
+    padding: 1px;
 }
 element-text {
     background-color: inherit;
@@ -73,14 +73,14 @@ element.alternate.active {
     text-color:       @alternate-active-foreground;
 }
 scrollbar {
-    width:        4px ;
+    width:        4px;
     border:       0;
     handle-color: @normal-foreground;
-    handle-width: 8px ;
+    handle-width: 8px;
     padding:      0;
 }
 mode-switcher {
-    border:       2px 0px 0px ;
+    border:       2px 0px 0px;
     border-color: @separatorcolor;
 }
 button {
@@ -94,7 +94,7 @@ button.selected {
 inputbar {
     spacing:    0;
     text-color: @normal-foreground;
-    padding:    1px ;
+    padding:    1px;
 }
 case-indicator {
     spacing:    0;
@@ -114,7 +114,7 @@ inputbar {
 textbox-prompt-colon {
     expand:     false;
     str:        ":";
-    margin:     0px 0.3em 0em 0em ;
+    margin:     0px 0.3em 0em 0em;
     text-color: @normal-foreground;
 }
 

--- a/.config/rofi/rofidmenu.rasi
+++ b/.config/rofi/rofidmenu.rasi
@@ -3,14 +3,14 @@
  * Maintainer: joekamprad <joekamprad@endeavouros.com>
  *******************************************************/
 configuration {
-    font:				"Noto Sans Regular 10";
-    show-icons:				true;
-    icon-theme:				"Qogir";
-    display-drun:			"Apps";
-    drun-display-format:		"{name}";
-    scroll-method:			0;
-    disable-history:			false;
-    sidebar-mode:			false;
+    font:                "Noto Sans Regular 10";
+    show-icons:          true;
+    icon-theme:          "Qogir";
+    display-drun:        "Apps";
+    drun-display-format: "{name}";
+    scroll-method:       0;
+    disable-history:     false;
+    sidebar-mode:        false;
 }
 
 @import "~/.config/rofi/arc_dark_transparent_colors.rasi"
@@ -21,32 +21,32 @@ window {
     padding:          30;
 }
 listview {
-    lines:                          10;
-    columns:                        3;
+    lines:   10;
+    columns: 3;
 }
 mainbox {
     border:  0;
     padding: 0;
 }
 message {
-    border:       2px 0px 0px ;
+    border:       2px 0px 0px;
     border-color: @separatorcolor;
-    padding:      1px ;
+    padding:      1px;
 }
 textbox {
     text-color: @foreground;
 }
 listview {
     fixed-height: 0;
-    border:       8px 0px 0px ;
+    border:       8px 0px 0px;
     border-color: @separatorcolor;
-    spacing:      8px ;
+    spacing:      8px;
     scrollbar:    false;
-    padding:      2px 0px 0px ;
+    padding:      2px 0px 0px;
 }
 element {
     border:  0;
-    padding: 1px ;
+    padding: 1px;
 }
 element-text {
     background-color: inherit;
@@ -89,14 +89,14 @@ element.alternate.active {
     text-color:       @alternate-active-foreground;
 }
 scrollbar {
-    width:        4px ;
+    width:        4px;
     border:       0;
     handle-color: @normal-foreground;
-    handle-width: 8px ;
+    handle-width: 8px;
     padding:      0;
 }
 mode-switcher {
-    border:       2px 0px 0px ;
+    border:       2px 0px 0px;
     border-color: @separatorcolor;
 }
 button {
@@ -110,7 +110,7 @@ button.selected {
 inputbar {
     spacing:    0;
     text-color: @normal-foreground;
-    padding:    1px ;
+    padding:    1px;
 }
 case-indicator {
     spacing:    0;
@@ -130,6 +130,6 @@ inputbar {
 textbox-prompt-colon {
     expand:     false;
     str:        ":";
-    margin:     0px 0.3em 0em 0em ;
+    margin:     0px 0.3em 0em 0em;
     text-color: @normal-foreground;
 }

--- a/.config/rofi/rofikeyhint.rasi
+++ b/.config/rofi/rofikeyhint.rasi
@@ -3,16 +3,16 @@
  * Maintainer: joekamprad <joekamprad@endeavouros.com>
  *******************************************************/
 configuration {
-    font:                           "Noto Sans Regular 10";
-    show-icons:                     false;
-	icon-theme: 					"Qogir";
-    display-drun: 					"KeyHint";
-    drun-display-format:            "{name}";
-    scroll-method:                  0;
-    disable-history:                false;
-    fullscreen:                     false;
-	hide-scrollbar: 				true;
-	sidebar-mode: 					false;
+    font:                "Noto Sans Regular 10";
+    show-icons:          false;
+    icon-theme:          "Qogir";
+    display-drun:        "KeyHint";
+    drun-display-format: "{name}";
+    scroll-method:       0;
+    disable-history:     false;
+    fullscreen:          false;
+    hide-scrollbar:      true;
+    sidebar-mode:        false;
 }
 
 @import "~/.config/rofi/arc_dark_transparent_colors.rasi"
@@ -23,32 +23,32 @@ window {
     padding:          30;
 }
 listview {
-    lines:                          10;
-    columns:                        1;
+    lines:   10;
+    columns: 1;
 }
 mainbox {
     border:  0;
     padding: 0;
 }
 message {
-    border:       2px 0px 0px ;
+    border:       2px 0px 0px;
     border-color: @separatorcolor;
-    padding:      1px ;
+    padding:      1px;
 }
 textbox {
     text-color: @foreground;
 }
 listview {
     fixed-height: 0;
-    border:       8px 0px 0px ;
+    border:       8px 0px 0px;
     border-color: @separatorcolor;
-    spacing:      8px ;
+    spacing:      8px;
     scrollbar:    false;
-    padding:      2px 0px 0px ;
+    padding:      2px 0px 0px;
 }
 element {
     border:  0;
-    padding: 1px ;
+    padding: 1px;
 }
 element-text {
     background-color: inherit;
@@ -91,14 +91,14 @@ element.alternate.active {
     text-color:       @alternate-active-foreground;
 }
 scrollbar {
-    width:        4px ;
+    width:        4px;
     border:       0;
     handle-color: @normal-foreground;
-    handle-width: 8px ;
+    handle-width: 8px;
     padding:      0;
 }
 mode-switcher {
-    border:       2px 0px 0px ;
+    border:       2px 0px 0px;
     border-color: @separatorcolor;
 }
 button {
@@ -112,7 +112,7 @@ button.selected {
 inputbar {
     spacing:    0;
     text-color: @normal-foreground;
-    padding:    1px ;
+    padding:    1px;
 }
 case-indicator {
     spacing:    0;
@@ -132,6 +132,6 @@ inputbar {
 textbox-prompt-colon {
     expand:     false;
     str:        ":";
-    margin:     0px 0.3em 0em 0em ;
+    margin:     0px 0.3em 0em 0em;
     text-color: @normal-foreground;
 }


### PR DESCRIPTION
Upon doing a fresh install of Endavour I took to comparing my dotfiles/config to the defaults to see what the changes were, but what I found was a bit of a mess.

A mixture of tabs and spaces were used, an attempt at value alignment was made for some properties but ignored for others, extra spacing in places, etc. This should correct all of that.

Hopefully this looks alright to all. I noticed some blocks (like `configuration`) typically had way more spacing than others, which I removed for consistency's sake. Not sure if that was intended or just incidental.