### PR TITLE
Fix typo in command to restore i3 default settings

### DIFF
--- a/force-knowledge.md
+++ b/force-knowledge.md
@@ -49,7 +49,7 @@ exec --no-startup-id dex --autostart --environment i3
 The default configuration file for i3 can be found at `/etc/i3/config`. The default configuration file for endeavouros-i3 can be found [here](https://raw.githubusercontent.com/endeavouros-team/endeavouros-i3wm-setup/main/.config/i3/config). To replace your current configuration with the default of endeavouros-i3 run the following command. This will also make a backup of your current configuration at `~/.config/i3/config.1`:
 
 ```
-wget --backups=1 https://raw.githubusercontent.com/endeavouros-team endeavouros-i3wm-setup/main/.config/i3/config -P ~/.config/i3/
+wget --backups=1 https://raw.githubusercontent.com/endeavouros-team/endeavouros-i3wm-setup/main/.config/i3/config -P ~/.config/i3/
 ```
 
 Still having some issues? Surf through the [EndeavourOS Wiki](https://discovery.endeavouros.com/window-tiling-managers/i3-wm/2021/03/) or ask for help on [EndeavourOS Forum](https://forum.endeavouros.com/).


### PR DESCRIPTION
Added a / in the link to the default configs to make the command work