### PR TITLE
copy xed.dconf to home in i3_install script

### DIFF
--- a/i3_install
+++ b/i3_install
@@ -4,6 +4,7 @@ cd endeavouros-i3wm-setup
 cp -R .config ~/                                            
 chmod -R +x ~/.config/i3/scripts
 cp .nanorc ~/
+cp xed.dconf ~/
 dbus-launch dconf load / < ~/xed.dconf
 sed -i 's|\(exec --no-startup-id ~/set_once.sh\)|# \1|' ~/.config/i3/config
 #wget https://raw.githubusercontent.com/endeavouros-team/EndeavourOS-packages-lists/master/i3


### PR DESCRIPTION
as dbus-launch fails, if there is no xed.dconf, it has to be copied to home dir first