### PR TITLE
Update powermenu - loading cursor bug

### DIFF
--- a/.config/i3/scripts/power-profiles
+++ b/.config/i3/scripts/power-profiles
@@ -176,7 +176,7 @@ function ask_confirmation() {
   fi
 
   if [ "${confirmed}" == 0 ]; then
-    i3-msg -q "exec ${menu[${selection}]}"
+    i3-msg -q "exec --no-startup-id ${menu[${selection}]}"
   fi
 }
 
@@ -185,6 +185,6 @@ if [[ $? -eq 0 && ! -z ${selection} ]]; then
         ${menu_confirm} =~ (^|[[:space:]])"${selection}"($|[[:space:]]) ]]; then
     ask_confirmation
   else
-    i3-msg -q "exec ${menu[${selection}]}"
+    i3-msg -q "exec --no-startup-id ${menu[${selection}]}"
   fi
 fi

--- a/.config/i3/scripts/powermenu
+++ b/.config/i3/scripts/powermenu
@@ -172,7 +172,7 @@ function ask_confirmation() {
   fi
 
   if [ "${confirmed}" == 0 ]; then
-    i3-msg -q "exec ${menu[${selection}]}"
+    i3-msg -q "exec --no-startup-id ${menu[${selection}]}"
   fi
 }
 
@@ -181,6 +181,6 @@ if [[ $? -eq 0 && ! -z ${selection} ]]; then
         ${menu_confirm} =~ (^|[[:space:]])"${selection}"($|[[:space:]]) ]]; then
     ask_confirmation
   else
-    i3-msg -q "exec ${menu[${selection}]}"
+    i3-msg -q "exec --no-startup-id ${menu[${selection}]}"
   fi
 fi


### PR DESCRIPTION
Fixes the infinite loading cursor on empty screen areas after locking from powermenu & selecting power modes