### PR TITLE
Adjust xbacklight call to work with acpilight

### DIFF
--- a/.config/i3/scripts/volume_brightness.sh
+++ b/.config/i3/scripts/volume_brightness.sh
@@ -21,7 +21,7 @@ function get_mute {
 
 # Uses regex to get brightness from xbacklight
 function get_brightness {
-    xbacklight | grep -Po '[0-9]{1,3}' | head -n 1
+    xbacklight -get | grep -Po '[0-9]{1,3}' | head -n 1
 }
 
 # Returns a mute icon, a volume-low icon, or a volume-high icon, depending on the volume


### PR DESCRIPTION
Replacing the `xbacklight` call sans arguments with the more verbose `xbacklight -get` ensures that the volume/brightness script works with both `xorg-xbacklight` and its drop-in replacement `acpilight`, which supports more modern hardware (see https://wiki.archlinux.org/title/Backlight and https://gitlab.com/wavexx/acpilight).