### PR TITLE
Make numpad keys work similarly for switching workspaces when numlock is on or off

### DIFF
--- a/etc/skel/.config/i3/config
+++ b/etc/skel/.config/i3/config
@@ -83,16 +83,16 @@ bindsym $mod+9    workspace  $ws9
 bindsym $mod+0    workspace  $ws10
 
 # switch to workspace with numpad keys
-bindcode $mod+87 workspace 1
-bindcode $mod+88 workspace 2
-bindcode $mod+89 workspace 3
-bindcode $mod+83 workspace 4
-bindcode $mod+84 workspace 5
-bindcode $mod+85 workspace 6
-bindcode $mod+79 workspace 7
-bindcode $mod+80 workspace 8
-bindcode $mod+81 workspace 9
-bindcode $mod+90 workspace 10
+bindcode $mod+87 workspace $ws1
+bindcode $mod+88 workspace $ws2
+bindcode $mod+89 workspace $ws3
+bindcode $mod+83 workspace $ws4
+bindcode $mod+84 workspace $ws5
+bindcode $mod+85 workspace $ws6
+bindcode $mod+79 workspace $ws7
+bindcode $mod+80 workspace $ws8
+bindcode $mod+81 workspace $ws9
+bindcode $mod+90 workspace $ws10
 
 # switch to workspace with numlock numpad keys
 bindcode $mod+Mod2+87 workspace $ws1


### PR DESCRIPTION
Apologies if this is intended functionality, but I didn't see that stated anywhere. 

This change makes it so that switching workspaces with the numpad works the same regardless of the state of numlock. 

Previously, if numlock was off then $mod + Numpad 1 would go to workspace 1 and not `$ws1`  while if numlock was on the $mod + Numpad 1 would go to `$ws1`.  This is confusing as if you cycle between having numlock on/off a lot then you'll go to different workspaces. 

Now, it has been updated so that $mod + Numpad 1 goes to `$ws1` when numlock is off.

(`$ws1` was an example, this functionality extends for all default workspace variables)

