### PR TITLE
Fix memory status/percentage display

### DIFF
--- a/etc/skel/.config/i3/scripts/memory
+++ b/etc/skel/.config/i3/scripts/memory
@@ -55,7 +55,7 @@ END {
 	# printf("%.1fG/%.1fG (%.f%%)\n", used, total, pct)
 
 	# short text
-	printf("%.f%%\n", pct)
+	printf("%02.f%%\n", pct)
 
 	# color
 	if (pct > 90) {


### PR DESCRIPTION
The CPU script in this same directory will display as such on the i3status: `09%` - while the memory status doesn't pad with a `0`, so it'll look like this by default `9%`. This fixes the script to pad with a `0` by default so the style is unified.