### PR TITLE
Fixed playerctl pause and play not working

### DIFF
--- a/etc/skel/.config/i3/config
+++ b/etc/skel/.config/i3/config
@@ -278,8 +278,8 @@ bindsym XF86AudioMute exec --no-startup-id ~/.config/i3/scripts/volume_brightnes
 bindsym XF86AudioMicMute exec amixer sset Capture toggle
 
 # audio control
-bindsym XF86AudioPlay exec --no-startup-id playerctl play
-bindsym XF86AudioPause exec --no-startup-id playerctl pause
+bindsym XF86AudioPlay exec --no-startup-id playerctl play-pause 
+# Above line will also work for pausing
 bindsym XF86AudioNext exec --no-startup-id playerctl next
 bindsym XF86AudioPrev exec --no-startup-id playerctl previous
 


### PR DESCRIPTION
edited the line 
bindsym XF86AudioPlay exec --no-startup-id playerctl play
to be:
bindsym XF86AudioPlay exec --no-startup-id playerctl play-pause 
And deleted the variant of the first line with pause entirely.
This is my first pull request ever, sorry for any hiccups.