### PR TITLE
Alternative brightness control option using brightnessctl

### DIFF
--- a/etc/skel/.config/i3/config
+++ b/etc/skel/.config/i3/config
@@ -202,8 +202,15 @@ bindsym F1 exec --no-startup-id ~/.config/i3/scripts/keyhint-2
 #bindsym XF86MonBrightnessUp exec --no-startup-id xbacklight +10 && notify-send "Brightness - $(xbacklight -get | cut -d '.' -f 1)%"
 #bindsym XF86MonBrightnessDown exec --no-startup-id xbacklight -10 && notify-send "Brightness - $(xbacklight -get | cut -d '.' -f 1)%"
 # Backlight setting using dunst osc
-bindsym XF86MonBrightnessUp exec --no-startup-id ~/.config/i3/scripts/volume_brightness.sh brightness_up
-bindsym XF86MonBrightnessDown exec --no-startup-id ~/.config/i3/scripts/volume_brightness.sh brightness_down
+bindsym XF86MonBrightnessUp exec --no-startup-id ~/.config/i3/scripts/volume_brightness.sh brightness_up_xbl 5
+bindsym XF86MonBrightnessDown exec --no-startup-id ~/.config/i3/scripts/volume_brightness.sh brightness_down_xbl 5
+# Alternative brightness control using brightnessctl 
+# backlightctl: https://archlinux.org/packages/extra/x86_64/brightnessctl/ (yay -S brightnessctl)
+#bindsym XF86MonBrightnessUp exec --no-startup-id brightnessctl set +10%
+#bindsym XF86MonBrightnessDown exec --no-startup-id brightnessctl set 10%-
+# Alternative brightness control using brightnessctl (with dunst notif)
+#bindsym XF86MonBrightnessUp exec --no-startup-id ~/.config/i3/scripts/volume_brightness.sh brightness_up_blctl 5
+#bindsym XF86MonBrightnessDown exec --no-startup-id ~/.config/i3/scripts/volume_brightness.sh brightness_down_blctl 5
 
 # change focus
 bindsym $mod+j focus left
@@ -262,8 +269,8 @@ bindsym $mod+Shift+n exec --no-startup-id ~/.config/i3/scripts/empty_workspace
 #bindsym XF86AudioRaiseVolume exec --no-startup-id amixer -D pulse sset Master 5%+ && pkill -RTMIN+1 i3blocks
 #bindsym XF86AudioLowerVolume exec --no-startup-id amixer -D pulse sset Master 5%- && pkill -RTMIN+1 i3blocks
 # use meta keys showing osc using dunst
-bindsym XF86AudioRaiseVolume exec --no-startup-id ~/.config/i3/scripts/volume_brightness.sh volume_up
-bindsym XF86AudioLowerVolume exec --no-startup-id ~/.config/i3/scripts/volume_brightness.sh volume_down
+bindsym XF86AudioRaiseVolume exec --no-startup-id ~/.config/i3/scripts/volume_brightness.sh volume_up 1
+bindsym XF86AudioLowerVolume exec --no-startup-id ~/.config/i3/scripts/volume_brightness.sh volume_down 1
 
 # gradular volume control
 bindsym $mod+XF86AudioRaiseVolume exec --no-startup-id amixer -D pulse sset Master 1%+ && pkill -RTMIN+1 i3blocks

--- a/etc/skel/.config/i3/config
+++ b/etc/skel/.config/i3/config
@@ -205,12 +205,12 @@ bindsym F1 exec --no-startup-id ~/.config/i3/scripts/keyhint-2
 bindsym XF86MonBrightnessUp exec --no-startup-id ~/.config/i3/scripts/volume_brightness.sh brightness_up_xbl 5
 bindsym XF86MonBrightnessDown exec --no-startup-id ~/.config/i3/scripts/volume_brightness.sh brightness_down_xbl 5
 # Alternative brightness control using brightnessctl 
-# backlightctl: https://archlinux.org/packages/extra/x86_64/brightnessctl/ (yay -S brightnessctl)
+# brightnessctl: https://archlinux.org/packages/extra/x86_64/brightnessctl/ (yay -S brightnessctl)
 #bindsym XF86MonBrightnessUp exec --no-startup-id brightnessctl set +10%
 #bindsym XF86MonBrightnessDown exec --no-startup-id brightnessctl set 10%-
 # Alternative brightness control using brightnessctl (with dunst notif)
-#bindsym XF86MonBrightnessUp exec --no-startup-id ~/.config/i3/scripts/volume_brightness.sh brightness_up_blctl 5
-#bindsym XF86MonBrightnessDown exec --no-startup-id ~/.config/i3/scripts/volume_brightness.sh brightness_down_blctl 5
+#bindsym XF86MonBrightnessUp exec --no-startup-id ~/.config/i3/scripts/volume_brightness.sh brightness_up_bctl 5
+#bindsym XF86MonBrightnessDown exec --no-startup-id ~/.config/i3/scripts/volume_brightness.sh brightness_down_bctl 5
 
 # change focus
 bindsym $mod+j focus left

--- a/etc/skel/.config/i3/scripts/volume_brightness.sh
+++ b/etc/skel/.config/i3/scripts/volume_brightness.sh
@@ -6,8 +6,7 @@
 # Modified to optionally use brightnessctl and pass in step sizes as arguments
 
 bar_color="#7f7fff"
-volume_step=$2
-brightness_step=$2
+step=$2
 max_volume=100
 
 # Uses regex to get volume from pactl
@@ -26,7 +25,7 @@ function get_brightness_xbl {
 }
 
 # Get brightness percentage from brightnessctl
-function get_brightness_blctl {
+function get_brightness_bctl {
      brightnessctl | awk -F'[()%]' '{print $2}' | tr -d '\n'
 }
 
@@ -63,29 +62,29 @@ function show_brightness_notif_xbl {
 }
 
 # Displays a brightness notification using dunstify
-function show_brightness_notif_blctl {
-    brightness=$(get_brightness_blctl)
+function show_brightness_notif_bctl {
+    brightness=$(get_brightness_bctl)
     get_brightness_icon
     dunstify -t 1000 -r 2593 -u normal "$brightness_icon $brightness%" -h int:value:$brightness -h string:hlcolor:$bar_color
 }
 
-# Main function - Takes user input, "volume_up", "volume_down", "brightness_up_xbl", "brightness_down_xbl", "brightness_up_blctl", or "brightness_down_blctl".
+# Main function - Takes user input, "volume_up", "volume_down", "brightness_up_xbl", "brightness_down_xbl", "brightness_up_bctl", or "brightness_down_bctl".
 case $1 in
     volume_up)
     # Unmutes and increases volume, then displays the notification
     pactl set-sink-mute @DEFAULT_SINK@ 0
     volume=$(get_volume)
-    if [ $(( "$volume" + "$volume_step" )) -gt $max_volume ]; then
+    if [ $(( "$volume" + "$step" )) -gt $max_volume ]; then
         pactl set-sink-volume @DEFAULT_SINK@ $max_volume%
     else
-        pactl set-sink-volume @DEFAULT_SINK@ +$volume_step%
+        pactl set-sink-volume @DEFAULT_SINK@ +$step%
     fi
     show_volume_notif
     ;;
 
     volume_down)
     # Raises volume and displays the notification
-    pactl set-sink-volume @DEFAULT_SINK@ -$volume_step%
+    pactl set-sink-volume @DEFAULT_SINK@ -$step%
     show_volume_notif
     ;;
 
@@ -97,25 +96,25 @@ case $1 in
 
     brightness_up_xbl)
     # Increases brightness and displays the notification
-    xbacklight -inc $brightness_step -time 0 
+    xbacklight -inc $step -time 0 
     show_brightness_notif_xbl
     ;;
 
     brightness_down_xbl)
     # Decreases brightness and displays the notification
-    xbacklight -dec $brightness_step -time 0
+    xbacklight -dec $step -time 0
     show_brightness_notif_xbl
     ;;
 
-    brightness_up_blctl)
+    brightness_up_bctl)
     # Increases brightness and displays the notification
-    brightnessctl set +$brightness_step%
-    show_brightness_notif_blctl
+    brightnessctl set +$step%
+    show_brightness_notif_bctl
     ;;
 
-    brightness_down_blctl)
+    brightness_down_bctl)
     # Decreases brightness and displays the notification
-    brightnessctl set $brightness_step%-
-    show_brightness_notif_blctl
+    brightnessctl set $step%-
+    show_brightness_notif_bctl
     ;;
 esac

--- a/etc/skel/.config/i3/scripts/volume_brightness.sh
+++ b/etc/skel/.config/i3/scripts/volume_brightness.sh
@@ -1,8 +1,6 @@
 #!/bin/bash
 # original source: https://gitlab.com/Nmoleo/i3-volume-brightness-indicator
 
-# taken from here: https://gitlab.com/Nmoleo/i3-volume-brightness-indicator
-
 # See README.md for usage instructions
 
 # Modified to optionally use brightnessctl and pass in step sizes as arguments


### PR DESCRIPTION
I can only control my ASUS TUF laptop using backlightctl, so I edited volume_brightness.sh and the i3 config to include a backlightctl option. While I was there, I made volume/brightness step size an argument for volume_brightness.sh so it can be set right in the i3 config.

If someone could test that the original method is still functional on their device, that'd be great.

This is my first ever PR so feedback is very much welcome :)