### PR TITLE
Adding tags / translation functionality to the i3block displaying the current power profile

### DIFF
--- a/etc/skel/.config/i3/scripts/ppd-status
+++ b/etc/skel/.config/i3/scripts/ppd-status
@@ -7,5 +7,19 @@
 
 # script to show current power profile
 
+# assign tags or translations to each profile
+declare -A tags
+tags=(
+  [performance]="Performance"
+  [balanced]="Balanced"
+  [power-saver]="Power saver"
+)
+
+# Get current profile 
 current_profile=$(/usr/bin/powerprofilesctl get)
-echo "$current_profile"
+
+# Get tag from the array
+profile_tag=${tags[$current_profile]}
+
+# Show tag on i3block
+echo "${profile_tag:-$current_profile}"


### PR DESCRIPTION
I modified the ppd-status script so I could display 'tags' instead the name of each `power-profiles-daemon` profile name. I think this looks more clean and adds functionality to display a translation for each name or a custom tag:

Edit: if ther's no 'tag' assgined to the current profile, it will just display the ppd profile name.

![performance](https://github.com/user-attachments/assets/bbda5820-01b2-41e3-a6ed-d9c16f1f9d26)
![balanced](https://github.com/user-attachments/assets/829fdba8-b5b7-4266-8b4b-53eaae3d6f53)
![rendimiento](https://github.com/user-attachments/assets/db8261cb-5968-4a0d-bafe-3fa5902e5adc)
