### PR TITLE
new volume_brightness2.sh script & whitespace straightening in i3 config

### DIFF
--- a/etc/skel/.config/i3/config
+++ b/etc/skel/.config/i3/config
@@ -119,28 +119,28 @@ bindcode $mod+Shift+18    move container to workspace  $ws9
 bindcode $mod+Shift+19    move container to workspace  $ws10
 
 # move focused container to workspace with numpad keys
-bindcode $mod+Shift+Mod2+87 	move container to workspace  $ws1
-bindcode $mod+Shift+Mod2+88 	move container to workspace  $ws2
-bindcode $mod+Shift+Mod2+89 	move container to workspace  $ws3
-bindcode $mod+Shift+Mod2+83 	move container to workspace  $ws4
-bindcode $mod+Shift+Mod2+84 	move container to workspace  $ws5
-bindcode $mod+Shift+Mod2+85 	move container to workspace  $ws6
-bindcode $mod+Shift+Mod2+79 	move container to workspace  $ws7
-bindcode $mod+Shift+Mod2+80 	move container to workspace  $ws8
-bindcode $mod+Shift+Mod2+81 	move container to workspace  $ws9
-bindcode $mod+Shift+Mod2+90 	move container to workspace  $ws10
+bindcode $mod+Shift+Mod2+87     move container to workspace  $ws1
+bindcode $mod+Shift+Mod2+88     move container to workspace  $ws2
+bindcode $mod+Shift+Mod2+89     move container to workspace  $ws3
+bindcode $mod+Shift+Mod2+83     move container to workspace  $ws4
+bindcode $mod+Shift+Mod2+84     move container to workspace  $ws5
+bindcode $mod+Shift+Mod2+85     move container to workspace  $ws6
+bindcode $mod+Shift+Mod2+79     move container to workspace  $ws7
+bindcode $mod+Shift+Mod2+80     move container to workspace  $ws8
+bindcode $mod+Shift+Mod2+81     move container to workspace  $ws9
+bindcode $mod+Shift+Mod2+90     move container to workspace  $ws10
 
 # move focused container to workspace with numpad keys
-bindcode $mod+Shift+87 	 move container to workspace  $ws1
-bindcode $mod+Shift+88 	 move container to workspace  $ws2
-bindcode $mod+Shift+89 	 move container to workspace  $ws3
-bindcode $mod+Shift+83 	 move container to workspace  $ws4
-bindcode $mod+Shift+84 	 move container to workspace  $ws5
-bindcode $mod+Shift+85 	 move container to workspace  $ws6
-bindcode $mod+Shift+79 	 move container to workspace  $ws7
-bindcode $mod+Shift+80 	 move container to workspace  $ws8
-bindcode $mod+Shift+81 	 move container to workspace  $ws9
-bindcode $mod+Shift+90 	 move container to workspace  $ws10
+bindcode $mod+Shift+87   move container to workspace  $ws1
+bindcode $mod+Shift+88   move container to workspace  $ws2
+bindcode $mod+Shift+89   move container to workspace  $ws3
+bindcode $mod+Shift+83   move container to workspace  $ws4
+bindcode $mod+Shift+84   move container to workspace  $ws5
+bindcode $mod+Shift+85   move container to workspace  $ws6
+bindcode $mod+Shift+79   move container to workspace  $ws7
+bindcode $mod+Shift+80   move container to workspace  $ws8
+bindcode $mod+Shift+81   move container to workspace  $ws9
+bindcode $mod+Shift+90   move container to workspace  $ws10
 
 # resize window (you can also use the mouse for that):
 #mode "resize" {
@@ -161,7 +161,7 @@ bindcode $mod+Shift+90 	 move container to workspace  $ws10
 #        bindsym Right resize grow width 10 px or 10 ppt
 
 # back to normal: Enter or Escape
-#	     bindsym Return mode "default"
+#        bindsym Return mode "default"
 #        bindsym Escape mode "default"
 #}
 
@@ -206,6 +206,16 @@ bindsym F1 exec --no-startup-id ~/.config/i3/scripts/keyhint-2
 # Backlight setting using dunst osc
 bindsym XF86MonBrightnessUp exec --no-startup-id ~/.config/i3/scripts/volume_brightness.sh brightness_up
 bindsym XF86MonBrightnessDown exec --no-startup-id ~/.config/i3/scripts/volume_brightness.sh brightness_down
+a
+
+# alternative screen & keyboard brightness setting with brightnessctl using dunst osc
+# install brightnessctl to work (sudo pacman -S brightnessctl)
+# keyboard backlight setting using brightnessctl
+#bindsym Mod1+space       exec --no-startup-id ~/.config/i3/scripts/volume_brightness2.sh keyboard_brightness_up
+#bindsym Mod1+Shift+space exec --no-startup-id ~/.config/i3/scripts/volume_brightness2.sh keyboard_brightness_down
+## screen brightness setting using brightnessctl
+#bindsym XF86MonBrightnessUp   exec --no-startup-id ~/.config/i3/scripts/volume_brightness2.sh screen_brightness_up
+#bindsym XF86MonBrightnessDown exec --no-startup-id ~/.config/i3/scripts/volume_brightness2.sh screen_brightness_down
 
 # change focus
 bindsym $mod+j focus left
@@ -280,7 +290,7 @@ bindsym XF86AudioMute exec --no-startup-id ~/.config/i3/scripts/volume_brightnes
 bindsym XF86AudioMicMute exec amixer sset Capture toggle
 
 # audio control
-bindsym XF86AudioPlay exec --no-startup-id playerctl play-pause 
+bindsym XF86AudioPlay exec --no-startup-id playerctl play-pause
 # Above line will also work for pausing
 bindsym XF86AudioNext exec --no-startup-id playerctl next
 bindsym XF86AudioPrev exec --no-startup-id playerctl previous
@@ -356,10 +366,10 @@ for_window [class=TelegramDesktop] focus
 #
 # picom: https://wiki.archlinux.org/title/Picom
 # manpage: https://man.archlinux.org/man/picom.1.en
-# The default configuration is available in /etc/xdg/picom.conf 
+# The default configuration is available in /etc/xdg/picom.conf
 # For modifications, it can be copied to ~/.config/picom/picom.conf or ~/.config/picom.conf
 # install picom package (yay -S picom)
-# start using default config 
+# start using default config
 #exec_always --no-startup-id picom -b
 #
 # for custom config:
@@ -381,7 +391,7 @@ exec --no-startup-id /usr/lib/polkit-gnome/polkit-gnome-authentication-agent-1
 exec --no-startup-id dex --autostart --environment i3
 
 # start welcome app
-#exec --no-startup-id sh /usr/share/endeavouros/scripts/welcome --startdelay=3 
+#exec --no-startup-id sh /usr/share/endeavouros/scripts/welcome --startdelay=3
 
 # num lock activated
 #exec --no-startup-id numlockx on
@@ -419,7 +429,7 @@ exec --no-startup-id xset s 480 dpms 600 600 600
 # dunst config used ~/.config/dunst/dunstrc
 # set alternative config if needed:
 #exec --no-startup-id /usr/bin/dunst --config ~/.config/dunst/dunstrc
-# may need to run dbus-launch explicitly: 
+# may need to run dbus-launch explicitly:
 #exec --no-startup-id dbus-launch /usr/bin/dunst
 exec --no-startup-id /usr/bin/dunst
 # alternative if you installed aside with XFCE4:
@@ -473,7 +483,7 @@ for_window [class="urxvt"] border pixel 1
 
 # set size of floating window
 #for_window [window_role="(?i)GtkFileChooserDialog"] resize set 640 480 #to set size of file choose dialog
-#for_window [class=".*"] resize set 640 480 #to change size of all floating windows 
+#for_window [class=".*"] resize set 640 480 #to change size of all floating windows
 
 # set position of floating window
 #for_window [class=".*"] move position center
@@ -483,24 +493,24 @@ for_window [class="urxvt"] border pixel 1
 ######################################
 
 # Define colors variables:
-set $darkbluetrans	#08052be6
-set $darkblue		#08052b
-set $lightblue		#5294e2
-set $urgentred		#e53935
-set $white		#ffffff
-set $black		#000000
-set $purple		#e345ff
-set $darkgrey		#383c4a
-set $grey		#b0b5bd
-set $mediumgrey		#8b8b8b
-set $yellowbrown	#e1b700
+set $darkbluetrans  #08052be6
+set $darkblue       #08052b
+set $lightblue      #5294e2
+set $urgentred      #e53935
+set $white      #ffffff
+set $black      #000000
+set $purple     #e345ff
+set $darkgrey       #383c4a
+set $grey       #b0b5bd
+set $mediumgrey     #8b8b8b
+set $yellowbrown    #e1b700
 
 # define colors for windows:
-#class		        	border		bground		text		indicator	child_border
-client.focused		    	$lightblue	$darkblue	$white		$mediumgrey	$mediumgrey
-client.unfocused	    	$darkblue	$darkblue	$grey		$darkgrey	$darkgrey
-client.focused_inactive		$darkblue	$darkblue	$grey		$black		$black
-client.urgent		    	$urgentred	$urgentred	$white		$yellowbrown	$yellowbrown
+#class                  border      bground     text        indicator   child_border
+client.focused              $lightblue  $darkblue   $white      $mediumgrey $mediumgrey
+client.unfocused            $darkblue   $darkblue   $grey       $darkgrey   $darkgrey
+client.focused_inactive     $darkblue   $darkblue   $grey       $black      $black
+client.urgent               $urgentred  $urgentred  $white      $yellowbrown    $yellowbrown
 
 ############################################
 # bar settings (input comes from i3blocks) #
@@ -509,14 +519,14 @@ client.urgent		    	$urgentred	$urgentred	$white		$yellowbrown	$yellowbrown
 # Start i3bar to display a workspace bar
 # (plus the system information i3status finds out, if available)
 bar {
-		font pango: Noto Sans Regular 10
-		status_command i3blocks -c ~/.config/i3/i3blocks.conf
-	    	position bottom
-#	    	i3bar_command i3bar --transparency
+        font pango: Noto Sans Regular 10
+        status_command i3blocks -c ~/.config/i3/i3blocks.conf
+            position bottom
+#           i3bar_command i3bar --transparency
 # it could be that you have no primary display set: set one (xrandr --output <output> --primary)
 # reference: https://i3wm.org/docs/userguide.html#_tray_output
-		    #tray_output primary
-		    tray_padding 0
+            #tray_output primary
+            tray_padding 0
 
 # When strip_workspace_numbers is set to yes,
 # any workspace that has a name of the form
@@ -524,16 +534,16 @@ bar {
 strip_workspace_numbers yes
 ##strip_workspace_name no
 
-		    colors {
-		    separator          $purple
-		    background         $darkgrey
-		    statusline         $white
-#                          		border 		        bg		txt		indicator
-		focused_workspace	$mediumgrey	   	$grey		$darkgrey	$purple
-		active_workspace	$lightblue      	$mediumgrey	$darkgrey	$purple
-		inactive_workspace	$darkgrey   		$darkgrey	$grey		$purple
-		urgent_workspace	$urgentred	    	$urgentred	$white		$purple
-	}
+            colors {
+            separator          $purple
+            background         $darkgrey
+            statusline         $white
+#                               border              bg         txt     indicator
+        focused_workspace   $mediumgrey         $grey       $darkgrey   $purple
+        active_workspace    $lightblue          $mediumgrey $darkgrey   $purple
+        inactive_workspace  $darkgrey           $darkgrey   $grey       $purple
+        urgent_workspace    $urgentred          $urgentred  $white      $purple
+    }
 }
 
 # you can add different bars for multidisplay setups on each display:
@@ -543,11 +553,11 @@ strip_workspace_numbers yes
 # #08052be6 --> e6=90%
 
 # bar {
-#	font pango: Noto Sans Regular 10
-#	status_command i3blocks -c ~/.config/i3/i3blocks-2.conf
-#	i3bar_command i3bar --transparency
-#	output HDMI-0
-#	position bottom
+#   font pango: Noto Sans Regular 10
+#   status_command i3blocks -c ~/.config/i3/i3blocks-2.conf
+#   i3bar_command i3bar --transparency
+#   output HDMI-0
+#   position bottom
 #
 # When strip_workspace_numbers is set to yes,
 # any workspace that has a name of the form
@@ -555,16 +565,16 @@ strip_workspace_numbers yes
 #strip_workspace_numbers yes
 ##strip_workspace_name no
 #
-#	colors {
-#		separator          $purple
-#		background         $darkbluetrans
-#        	statusline         $white
-#					border		bg		txt		indicator
-#		focused_workspace	$lighterblue	$lighterblue	$darkblue	$purple
-#		active_workspace	$lightdblue	$lightdblue	$darkblue	$purple
-#		inactive_workspace	$darkblue	$darkblue	$lightdblue	$purple
-#		urgent_workspace	$urgentred	$urgentred	$white		$purple
-#	}
+#   colors {
+#       separator          $purple
+#       background         $darkbluetrans
+#           statusline         $white
+#                   border      bg      txt     indicator
+#       focused_workspace   $lighterblue    $lighterblue    $darkblue   $purple
+#       active_workspace    $lightdblue $lightdblue $darkblue   $purple
+#       inactive_workspace  $darkblue   $darkblue   $lightdblue $purple
+#       urgent_workspace    $urgentred  $urgentred  $white      $purple
+#   }
 #}
 
 #####################################
@@ -574,21 +584,21 @@ strip_workspace_numbers yes
 ## rofi bindings fancy application menu ($mod+d /F9 optional disabled)
 
 bindsym $mod+d exec --no-startup-id rofi -modi drun -show drun \
-		-config ~/.config/rofi/rofidmenu.rasi
+        -config ~/.config/rofi/rofidmenu.rasi
 
 #bindsym F9 exec --no-startup-id rofi -modi drun -show drun \
-#		-config ~/.config/rofi/rofidmenu.rasi
+#       -config ~/.config/rofi/rofidmenu.rasi
 
 ## rofi bindings for window menu ($mod+t /F10 optional disabled)
 
 bindsym $mod+t exec --no-startup-id rofi -show window \
-		-config ~/.config/rofi/rofidmenu.rasi
+        -config ~/.config/rofi/rofidmenu.rasi
 
 #bindsym F10 exec --no-startup-id rofi -show window \
-#		-config ~/.config/rofi/rofidmenu.rasi
+#       -config ~/.config/rofi/rofidmenu.rasi
 
 ## rofi bindings to manage clipboard (install rofi-greenclip from the AUR)
 
 #exec --no-startup-id greenclip daemon>/dev/null
 #bindsym $mod+c exec --no-startup-id rofi -modi "clipboard:greenclip print" -show clipboard \
-#		-config ~/.config/rofi/rofidmenu.rasi
+#       -config ~/.config/rofi/rofidmenu.rasi

--- a/etc/skel/.config/i3/config
+++ b/etc/skel/.config/i3/config
@@ -206,14 +206,15 @@ bindsym F1 exec --no-startup-id ~/.config/i3/scripts/keyhint-2
 # Backlight setting using dunst osc
 bindsym XF86MonBrightnessUp exec --no-startup-id ~/.config/i3/scripts/volume_brightness.sh brightness_up
 bindsym XF86MonBrightnessDown exec --no-startup-id ~/.config/i3/scripts/volume_brightness.sh brightness_down
-a
 
 # alternative screen & keyboard brightness setting with brightnessctl using dunst osc
-# install brightnessctl to work (sudo pacman -S brightnessctl)
+# install brightnessctl (sudo pacman -S brightnessctl)
+# then specify the device in volume_brightness2.sh using the grep command there
 # keyboard backlight setting using brightnessctl
 #bindsym Mod1+space       exec --no-startup-id ~/.config/i3/scripts/volume_brightness2.sh keyboard_brightness_up
 #bindsym Mod1+Shift+space exec --no-startup-id ~/.config/i3/scripts/volume_brightness2.sh keyboard_brightness_down
-## screen brightness setting using brightnessctl
+#
+# screen brightness setting using brightnessctl
 #bindsym XF86MonBrightnessUp   exec --no-startup-id ~/.config/i3/scripts/volume_brightness2.sh screen_brightness_up
 #bindsym XF86MonBrightnessDown exec --no-startup-id ~/.config/i3/scripts/volume_brightness2.sh screen_brightness_down
 
@@ -497,16 +498,16 @@ set $darkbluetrans  #08052be6
 set $darkblue       #08052b
 set $lightblue      #5294e2
 set $urgentred      #e53935
-set $white      #ffffff
-set $black      #000000
-set $purple     #e345ff
+set $white          #ffffff
+set $black          #000000
+set $purple         #e345ff
 set $darkgrey       #383c4a
-set $grey       #b0b5bd
+set $grey           #b0b5bd
 set $mediumgrey     #8b8b8b
 set $yellowbrown    #e1b700
 
 # define colors for windows:
-#class                  border      bground     text        indicator   child_border
+#class                      border      bground     text        indicator   child_border
 client.focused              $lightblue  $darkblue   $white      $mediumgrey $mediumgrey
 client.unfocused            $darkblue   $darkblue   $grey       $darkgrey   $darkgrey
 client.focused_inactive     $darkblue   $darkblue   $grey       $black      $black
@@ -538,7 +539,7 @@ strip_workspace_numbers yes
             separator          $purple
             background         $darkgrey
             statusline         $white
-#                               border              bg         txt     indicator
+#                           border              bg          txt         indicator
         focused_workspace   $mediumgrey         $grey       $darkgrey   $purple
         active_workspace    $lightblue          $mediumgrey $darkgrey   $purple
         inactive_workspace  $darkgrey           $darkgrey   $grey       $purple
@@ -569,11 +570,11 @@ strip_workspace_numbers yes
 #       separator          $purple
 #       background         $darkbluetrans
 #           statusline         $white
-#                   border      bg      txt     indicator
+#                           border          bg              txt         indicator
 #       focused_workspace   $lighterblue    $lighterblue    $darkblue   $purple
-#       active_workspace    $lightdblue $lightdblue $darkblue   $purple
-#       inactive_workspace  $darkblue   $darkblue   $lightdblue $purple
-#       urgent_workspace    $urgentred  $urgentred  $white      $purple
+#       active_workspace    $lightdblue     $lightdblue     $darkblue   $purple
+#       inactive_workspace  $darkblue       $darkblue       $lightdblue $purple
+#       urgent_workspace    $urgentred      $urgentred      $white      $purple
 #   }
 #}
 

--- a/etc/skel/.config/i3/scripts/volume_brightness2.sh
+++ b/etc/skel/.config/i3/scripts/volume_brightness2.sh
@@ -1,0 +1,170 @@
+#!/bin/bash
+# original source: https://gitlab.com/Nmoleo/i3-volume-brightness-indicator
+# alternative to volume_brightness.sh that uses brightnessctl for both keyboard & screen brightness
+
+# See README.md for usage instructions
+volume_step=1
+keyboard_brightness_step=20
+screen_brightness_step=1
+max_volume=100
+notification_timeout=1000
+
+# Specify Icon Theme here
+volume_theme_icon="audio-volume-high"
+screen_brightness_theme_icon="display-brightness"
+keyboard_brightness_theme_icon="display-brightness"
+
+# Keyboard Backlight device here:
+# copy result from (brightnessctl --list | grep -Po '\w+::kbd_backlight') to device
+device="chromeos::kbd_backlight"
+
+### Auto-detect keyboard and cache alternative here: (uncomment and delete device if wanted)
+# device_cache="/tmp/kbd_backlight_device"
+#
+# if [ -f "$device_cache" ]; then         # If there is cache, load it into device
+#     device=$(cat "$device_cache")
+# else                                    # If there is no cache, create one
+#     device=$(brightnessctl --list | grep -Po '\w+::kbd_backlight')
+#     echo "$device" > "$device_cache"
+# fi
+
+# Uses regex to get volume from pactl
+function get_volume {
+    pactl get-sink-volume @DEFAULT_SINK@ | grep -Po '[0-9]{1,3}(?=%)' | head -1
+}
+
+# Uses regex to get mute status from pactl
+function get_mute {
+    pactl get-sink-mute @DEFAULT_SINK@ | grep -Po '(?<=Mute: )(yes|no)'
+}
+
+# Get keyboard_brightness from brightnessctl
+function get_keyboard_brightness {
+    if [ -n "$device" ]; then
+        curr=$(brightnessctl -d "$device" get)
+        echo $(( curr ))
+    else
+        echo "No keyboard backlight device found"
+    fi
+}
+
+
+# Grabs screen brightness and formats it out of 100
+function get_screen_brightness {
+    curr=$(brightnessctl -q get)
+    max=$(brightnessctl -q max)
+    echo $(( curr * 100 / max ))
+}
+
+# Returns a mute icon, a volume-low icon, or a volume-high icon, depending on the volume
+function get_volume_icon {
+    volume=$(get_volume)
+    mute=$(get_mute)
+    if [ "$volume" -eq 0 ] || [ "$mute" == "yes" ] ; then
+        volume_icon=""
+    elif [ "$volume" -lt 50 ] ; then
+        volume_icon=""
+    else
+        volume_icon=""
+    fi
+}
+
+# Always returns the same icon - I couldn't get the brightness-low icon to work with fontawesome
+function get_keyboard_brightness_icon {
+    kb_brightness=$(get_keyboard_brightness)
+    if [ "$kb_brightness" -eq 0 ] ; then
+        keyboard_brightness_icon=""  # unfilled circle
+    elif [ "$kb_brightness" -lt 50 ] ; then
+        keyboard_brightness_icon=""  # fa-adjust (low brightness)
+    else
+        keyboard_brightness_icon=""  # full circle (high brightness)
+    fi
+}
+
+function get_screen_brightness_icon {
+    sc_brightness=$(get_screen_brightness)
+    if [ "$sc_brightness" -eq 0 ] ; then
+        screen_brightness_icon=""  # unfilled circle
+    elif [ "$sc_brightness" -lt 50 ] ; then
+        screen_brightness_icon=""  # fa-adjust (low brightness)
+    else
+        screen_brightness_icon=""  # full circle (high brightness)
+    fi
+}
+
+# Displays a volume notification using notify-send
+function show_volume_notif {
+    mute=$(get_mute)
+    volume=$(get_volume)
+    get_volume_icon
+    notify-send -i $volume_theme_icon -t $notification_timeout "Volume" "$volume_icon $volume%" -h int:value:$volume -h string:x-canonical-private-synchronous:volume
+}
+
+# Displays a keyboard_brightness notification
+function show_keyboard_brightness_notif {
+    keyboard_brightness=$(get_keyboard_brightness)
+    # Debug Purposes:
+    # echo $keyboard_brightness
+    get_keyboard_brightness_icon
+    notify-send -i $keyboard_brightness_theme_icon -t $notification_timeout "Keyboard Brightness" -h string:x-dunst-stack-tag:keyboard_brightness_notif -h int:value:$keyboard_brightness "$keyboard_brightness_icon $keyboard_brightness%"
+}
+
+# Displays a screen_brightness notification
+function show_screen_brightness_notif {
+    screen_brightness=$(get_screen_brightness)
+    # Debug Purposes:
+    # echo $screen_brightness
+    get_screen_brightness_icon
+    notify-send -i $screen_brightness_theme_icon -t $notification_timeout "Screen Brightness" -h string:x-dunst-stack-tag:screen_brightness_notif -h int:value:$screen_brightness "$screen_brightness_icon $screen_brightness%"
+}
+
+# Main function - Takes user input, "volume_up", "volume_down", "keyboard_brightness_up", "keyboard_brightness_down", "brightness_up", or "brightness_down"
+case $1 in
+    volume_up)
+    # Unmutes and increases volume, then displays the notification
+    pactl set-sink-mute @DEFAULT_SINK@ 0
+    volume=$(get_volume)
+    if [ $(( "$volume" + "$volume_step" )) -gt $max_volume ]; then
+        pactl set-sink-volume @DEFAULT_SINK@ $max_volume%
+    else
+        pactl set-sink-volume @DEFAULT_SINK@ +$volume_step%
+    fi
+    show_volume_notif
+    ;;
+
+    volume_down)
+    # Raises volume and displays the notification
+    pactl set-sink-volume @DEFAULT_SINK@ -$volume_step%
+    show_volume_notif
+    ;;
+
+    volume_mute)
+    # Toggles mute and displays the notification
+    pactl set-sink-mute @DEFAULT_SINK@ toggle
+    show_volume_notif
+    ;;
+
+    keyboard_brightness_up)
+    # Increases keyboard brightness and displays the notification
+    brightnessctl -d "$device" set ${keyboard_brightness_step}+
+    show_keyboard_brightness_notif
+    ;;
+
+    keyboard_brightness_down)
+    # Decreases keyboard brightness and displays the notification
+    brightnessctl -d "$device" set ${keyboard_brightness_step}-
+    show_keyboard_brightness_notif
+    ;;
+
+    screen_brightness_up)
+    # Increases screen brightness and displays the notification
+    brightnessctl -q set ${screen_brightness_step}%+
+    show_screen_brightness_notif
+    ;;
+
+    screen_brightness_down)
+    # Decreases screen brightness and displays the notification
+    brightnessctl -q set ${screen_brightness_step}%-
+    show_screen_brightness_notif
+    ;;
+esac


### PR DESCRIPTION
new script to adjust brightness for both screen & keyboard using brightnessctl with a segment in the i3 config advising as such. 
also took the liberty to straighten out the tabs in the i3 config file.