### PR TITLE
fix(openweather): update to One Call API 3.0 and enforce HTTPS usage

### DIFF
--- a/etc/skel/.config/i3/scripts/openweather
+++ b/etc/skel/.config/i3/scripts/openweather
@@ -14,7 +14,7 @@ APIKEY="keykeykey"
 # And get your Latitute and Longitudes to put in here:
 LAT="XX.XXXX"
 LON="XX.XXXX"
-URL="http://api.openweathermap.org/data/2.5/onecall?lat=${LAT}&lon=${LON}&units=metric&exclude=minutely,hourly,daily&APPID=${APIKEY}"
+URL="https://api.openweathermap.org/data/3.0/onecall?lat=${LAT}&lon=${LON}&units=metric&exclude=minutely,hourly,daily&appid=${APIKEY}"
 WEATHER_RESPONSE=$(wget -qO- "${URL}")
 
 WEATHER_CONDITION=$(echo "$WEATHER_RESPONSE" | jq '.current.weather[0].main' | sed 's/"//g')

--- a/etc/skel/.config/i3/scripts/openweather-city
+++ b/etc/skel/.config/i3/scripts/openweather-city
@@ -11,7 +11,7 @@ APIKEY="keykey"
 # find your City ID here: https://openweathermap.org/
 # search for your city and copy the ID from the URL inside the browser.
 CITY_ID="idid"
-URL="http://api.openweathermap.org/data/2.5/weather?id=${CITY_ID}&units=metric&APPID=${APIKEY}"
+URL="https://api.openweathermap.org/data/2.5/weather?id=${CITY_ID}&units=metric&APPID=${APIKEY}"
 
 WEATHER_RESPONSE=$(timeout --signal=1 2s curl -s "${URL}") ||  exit 1;
 


### PR DESCRIPTION
## Problem

The current API URL used in `etc/skel/.config/i3/scripts/openweather` is outdated and returns the following error when called:

``` json
{
	"cod": 401,
	"message": "Invalid API key. Please see https://openweathermap.org/faq#error401 for more info."
}
```

## Solution

- Updated API endpoint URL to current **One Call API 3.0** version according to the official OpenWeather [documentation](https://openweathermap.org/api/one-call-3#how).

- Additionally enforced the use of **HTTPS** protocol instead of HTTP for API calls in both `etc/skel/.config/i3/scripts/openweather` and `etc/skel/.config/i3/scripts/openweather-city` to ensure secure communication and prevent man-in-the-middle (MITM) attacks.

> **Note on paths:** These are the repo paths. On the user's system, the scripts typically reside at `~/.config/i3/scripts/`.

## Note

This is my first ever PR. I've been using the i3 edition of EndeavourOS as my primary setup, and it's been a huge help. I noticed this small issue and wanted to contribute a fix to help others using the same environment. If there's anything I should adjust, I'm happy to do so.