### PR TITLE
Update blur-lock for security

### DIFF
--- a/etc/skel/.config/i3/scripts/blur-lock
+++ b/etc/skel/.config/i3/scripts/blur-lock
@@ -10,4 +10,5 @@ BLUR="5x4"
 $SCREENSHOT
 magick $PICTURE -blur $BLUR $PICTURE
 i3lock -i $PICTURE
+shred $PICTURE
 rm $PICTURE


### PR DESCRIPTION
To enhance system security, the blur-lock script should shred the screenshot before deletion to prevent sensitive information from being recovered.